### PR TITLE
refactor: replace router navigation with Link component

### DIFF
--- a/apps/web/src/components/Leaderboard.tsx
+++ b/apps/web/src/components/Leaderboard.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import useSWR from 'swr';
-import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import { fetcher } from '@/lib/api';
 import { fixEncoding } from '@/lib/utils';
 import {
@@ -61,7 +61,6 @@ export function Leaderboard() {
   const [page, setPage] = useState(1);
   const [region, setRegion] = useState('all');
   const [sortBy, setSortBy] = useState('rating');
-  const router = useRouter();
 
   const basePath =
     bracket === '1v1'
@@ -243,88 +242,94 @@ export function Leaderboard() {
                 entries.map((p: any, i: number) => {
                   const globalRank = (page - 1) * PAGE_SIZE + i + 1;
                   const winrate = p.games > 0 ? (p.wins / p.games) * 100 : 0;
+                  const href = `/player/${p.brawlhallaId}`;
 
                   return (
                     <TableRow
                       key={p.brawlhallaId}
-                      role="link"
-                      tabIndex={0}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                          e.preventDefault();
-                          router.push(`/player/${p.brawlhallaId}`);
-                        }
-                      }}
-                      onClick={() => router.push(`/player/${p.brawlhallaId}`)}
                       className="border-border cursor-pointer transition-colors group h-16"
                     >
                       <TableCell
-                        className={`text-center ${getRankStyle(globalRank)}`}
+                        className={`p-0 text-center ${getRankStyle(
+                          globalRank
+                        )}`}
                       >
-                        #{globalRank}
+                        <Link href={href} className="block w-full h-full p-4">
+                          #{globalRank}
+                        </Link>
                       </TableCell>
-                      <TableCell>
-                        <div className="flex items-center gap-3">
-                          {/* Best Legend Avatar */}
-                          {p.bestLegendName && (
-                            <Avatar className="h-10 w-10 border border-border bg-muted rounded-md">
-                              <AvatarImage
-                                src={`/images/legends/avatars/${p.bestLegendNameKey}.png`}
-                                alt={p.bestLegendName}
-                                className="object-cover object-top"
-                                loading="lazy"
-                              />
-                              <AvatarFallback className="text-[10px] uppercase font-bold text-muted-foreground rounded-md">
-                                {p.bestLegendName.substring(0, 2)}
-                              </AvatarFallback>
-                            </Avatar>
-                          )}
-                          <div className="flex flex-col">
-                            <span className="font-bold text-foreground group-hover:text-primary transition-colors text-base truncate max-w-[200px]">
-                              {fixEncoding(p.name)}
-                            </span>
-                            <div className="flex items-center gap-2 mt-1">
-                              <span className="text-xs text-muted-foreground font-mono">
-                                {p.region}
+                      <TableCell className="p-0">
+                        <Link href={href} className="block w-full h-full p-4">
+                          <div className="flex items-center gap-3">
+                            {/* Best Legend Avatar */}
+                            {p.bestLegendName && (
+                              <Avatar className="h-10 w-10 border border-border bg-muted rounded-md">
+                                <AvatarImage
+                                  src={`/images/legends/avatars/${p.bestLegendNameKey}.png`}
+                                  alt={p.bestLegendName}
+                                  className="object-cover object-top"
+                                  loading="lazy"
+                                />
+                                <AvatarFallback className="text-[10px] uppercase font-bold text-muted-foreground rounded-md">
+                                  {p.bestLegendName.substring(0, 2)}
+                                </AvatarFallback>
+                              </Avatar>
+                            )}
+                            <div className="flex flex-col">
+                              <span className="font-bold text-foreground group-hover:text-primary transition-colors text-base truncate max-w-[200px]">
+                                {fixEncoding(p.name)}
                               </span>
-                              <Badge
-                                variant="secondary"
-                                className="text-[10px] px-1.5 py-0 h-5 font-normal bg-muted text-muted-foreground border-border"
-                              >
-                                {p.tier}
-                              </Badge>
+                              <div className="flex items-center gap-2 mt-1">
+                                <span className="text-xs text-muted-foreground font-mono">
+                                  {p.region}
+                                </span>
+                                <Badge
+                                  variant="secondary"
+                                  className="text-[10px] px-1.5 py-0 h-5 font-normal bg-muted text-muted-foreground border-border"
+                                >
+                                  {p.tier}
+                                </Badge>
+                              </div>
                             </div>
                           </div>
-                        </div>
+                        </Link>
                       </TableCell>
-                      <TableCell className="text-center">
-                        <div className="flex flex-col items-center">
-                          <span className="font-black text-foreground text-lg tracking-tight">
-                            {p.rating}
-                          </span>
-                          <span className="text-[10px] text-muted-foreground uppercase font-bold">
-                            Peak: {p.peakRating || '---'}
-                          </span>
-                        </div>
+                      <TableCell className="p-0 text-center">
+                        <Link href={href} className="block w-full h-full p-4">
+                          <div className="flex flex-col items-center">
+                            <span className="font-black text-foreground text-lg tracking-tight">
+                              {p.rating}
+                            </span>
+                            <span className="text-[10px] text-muted-foreground uppercase font-bold">
+                              Peak: {p.peakRating || '---'}
+                            </span>
+                          </div>
+                        </Link>
                       </TableCell>
-                      <TableCell className="text-center">
-                        <div
-                          className={`font-bold ${
-                            winrate >= 60
-                              ? 'text-green-500'
-                              : winrate >= 50
-                              ? 'text-primary'
-                              : 'text-muted-foreground'
-                          }`}
-                        >
-                          {winrate.toFixed(1)}%
-                        </div>
+                      <TableCell className="p-0 text-center">
+                        <Link href={href} className="block w-full h-full p-4">
+                          <div
+                            className={`font-bold ${
+                              winrate >= 60
+                                ? 'text-green-500'
+                                : winrate >= 50
+                                ? 'text-primary'
+                                : 'text-muted-foreground'
+                            }`}
+                          >
+                            {winrate.toFixed(1)}%
+                          </div>
+                        </Link>
                       </TableCell>
-                      <TableCell className="text-center hidden sm:table-cell text-muted-foreground font-mono">
-                        {p.wins}
+                      <TableCell className="p-0 text-center hidden sm:table-cell text-muted-foreground font-mono">
+                        <Link href={href} className="block w-full h-full p-4">
+                          {p.wins}
+                        </Link>
                       </TableCell>
-                      <TableCell className="text-center hidden sm:table-cell text-muted-foreground font-mono">
-                        {p.games}
+                      <TableCell className="p-0 text-center hidden sm:table-cell text-muted-foreground font-mono">
+                        <Link href={href} className="block w-full h-full p-4">
+                          {p.games}
+                        </Link>
                       </TableCell>
                     </TableRow>
                   );
@@ -347,25 +352,19 @@ export function Leaderboard() {
                       <TableCell>
                         <div className="flex flex-col">
                           <div className="font-bold text-foreground text-base max-w-[420px] md:max-w-[560px] whitespace-normal wrap-break-word leading-tight">
-                            <span
-                              className="cursor-pointer hover:text-primary"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                router.push(`/player/${t.brawlhallaIdOne}`);
-                              }}
+                            <Link
+                              href={`/player/${t.brawlhallaIdOne}`}
+                              className="hover:text-primary"
                             >
                               {fixEncoding(t.playerOneName || 'Unknown')}
-                            </span>
+                            </Link>
                             <span className="opacity-50"> + </span>
-                            <span
-                              className="cursor-pointer hover:text-primary"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                router.push(`/player/${t.brawlhallaIdTwo}`);
-                              }}
+                            <Link
+                              href={`/player/${t.brawlhallaIdTwo}`}
+                              className="hover:text-primary"
                             >
                               {fixEncoding(t.playerTwoName || 'Unknown')}
-                            </span>
+                            </Link>
                           </div>
                           <div className="flex items-center gap-2 mt-1 text-xs text-muted-foreground font-mono">
                             <span>{t.region}</span>

--- a/apps/web/src/components/SearchBar.tsx
+++ b/apps/web/src/components/SearchBar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useDebounce } from 'use-debounce';
 import { Shield } from 'lucide-react';
@@ -46,6 +47,16 @@ export function SearchBar({ onFocus, onBlur }: SearchBarProps) {
   const [error, setError] = useState<string | null>(null);
   const router = useRouter();
   const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleResultNavigate = (e: React.MouseEvent) => {
+    // Let the browser handle new-tab / new-window gestures.
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) {
+      return;
+    }
+    if (onBlur) onBlur();
+    setQuery('');
+    setError(null);
+  };
 
   // Handle click outside to clear query
   useEffect(() => {
@@ -172,10 +183,10 @@ export function SearchBar({ onFocus, onBlur }: SearchBarProps) {
             ) : (
               <>
                 {playerResults.map((p) => (
-                  <button
-                    type="button"
+                  <Link
                     key={`p-${p.brawlhallaId}`}
-                    onClick={() => router.push(`/player/${p.brawlhallaId}`)}
+                    href={`/player/${p.brawlhallaId}`}
+                    onClick={handleResultNavigate}
                     className="w-full text-left p-3 hover:bg-accent hover:text-accent-foreground border-b border-border last:border-0 flex justify-between items-center group transition-colors"
                   >
                     <div className="flex items-center gap-3">
@@ -210,7 +221,7 @@ export function SearchBar({ onFocus, onBlur }: SearchBarProps) {
                     <div className="text-sm font-mono text-primary">
                       {p.rating || '0'}
                     </div>
-                  </button>
+                  </Link>
                 ))}
 
                 {clanResults.length > 0 && (
@@ -229,10 +240,10 @@ export function SearchBar({ onFocus, onBlur }: SearchBarProps) {
 
                     {showClans &&
                       clanResults.map((c) => (
-                        <button
-                          type="button"
+                        <Link
                           key={`c-${c.clanId}`}
-                          onClick={() => router.push(`/clan/${c.clanId}`)}
+                          href={`/clan/${c.clanId}`}
+                          onClick={handleResultNavigate}
                           className="w-full text-left p-3 hover:bg-accent hover:text-accent-foreground border-b border-border last:border-0 flex justify-between items-center group transition-colors bg-muted/10"
                         >
                           <div className="flex items-center gap-3">
@@ -252,7 +263,7 @@ export function SearchBar({ onFocus, onBlur }: SearchBarProps) {
                             {c.xp ? parseInt(c.xp, 10).toLocaleString() : '0'}{' '}
                             XP
                           </div>
-                        </button>
+                        </Link>
                       ))}
                   </>
                 )}

--- a/apps/web/src/components/clan/ClanProfile.tsx
+++ b/apps/web/src/components/clan/ClanProfile.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 import { fixEncoding, timeAgo } from '@/lib/utils';
 import {
   Card,
@@ -52,7 +51,6 @@ interface ClanProfileProps {
 }
 
 export function ClanProfile({ initialData: clan, id }: ClanProfileProps) {
-  const router = useRouter();
   const [page, setPage] = useState(1);
   const [searchTerm, setSearchTerm] = useState('');
   const [sortBy, setSortBy] = useState<'default' | 'rating' | 'peakRating'>(
@@ -377,6 +375,7 @@ export function ClanProfile({ initialData: clan, id }: ClanProfileProps) {
                   paginatedMembers.map((member: any) => {
                     const totalClanXp = parseInt(clan.clanXp) || 1;
                     const contribution = (member.xp / totalClanXp) * 100;
+                    const href = `/player/${member.brawlhallaId}`;
                     const elo =
                       typeof member.elo === 'number' && member.elo > 0
                         ? member.elo
@@ -389,64 +388,71 @@ export function ClanProfile({ initialData: clan, id }: ClanProfileProps) {
                     return (
                       <TableRow
                         key={member.brawlhallaId}
-                        className="cursor-pointer border-border hover:bg-muted/50 transition-colors h-16"
-                        onClick={() =>
-                          router.push(`/player/${member.brawlhallaId}`)
-                        }
+                        className="border-border hover:bg-muted/50 transition-colors h-16 group"
                       >
-                        <TableCell>
-                          <div className="flex items-center justify-center">
-                            {getRankIcon(member.rank)}
-                          </div>
-                        </TableCell>
-                        <TableCell>
-                          <div className="flex items-center gap-3">
-                            <Avatar className="h-10 w-10 border border-border bg-muted rounded-md">
-                              <AvatarImage
-                                src={
-                                  member.legendNameKey
-                                    ? `/images/legends/avatars/${member.legendNameKey.toLowerCase()}.png`
-                                    : undefined
-                                }
-                                alt={member.legendNameKey || 'Legend'}
-                                className="object-cover object-top"
-                                loading="lazy"
-                              />
-                              <AvatarFallback className="text-[10px] uppercase font-bold text-muted-foreground rounded-md">
-                                {fixEncoding(member.name).substring(0, 2)}
-                              </AvatarFallback>
-                            </Avatar>
-                            <span className="font-bold text-lg text-foreground group-hover:text-primary transition-colors">
-                              {fixEncoding(member.name)}
-                            </span>
-                          </div>
-                        </TableCell>
-                        <TableCell className="text-right font-mono">
-                          {elo === null ? (
-                            <span className="text-muted-foreground">—</span>
-                          ) : (
-                            <div className="flex flex-col items-end leading-tight">
-                              <span className="font-bold">{elo}</span>
-                              {peakElo !== null && (
-                                <span className="text-xs text-muted-foreground">
-                                  Peak {peakElo}
-                                </span>
-                              )}
+                        <TableCell className="p-0">
+                          <Link href={href} className="block w-full h-full p-4">
+                            <div className="flex items-center justify-center">
+                              {getRankIcon(member.rank)}
                             </div>
-                          )}
+                          </Link>
                         </TableCell>
-                        <TableCell className="text-right font-mono">
-                          <div className="flex flex-col items-end leading-tight">
-                            <span className="font-bold">
-                              {member.xp.toLocaleString()}
-                            </span>
-                            <span className="text-xs text-muted-foreground">
-                              {contribution.toFixed(1)}%
-                            </span>
-                          </div>
+                        <TableCell className="p-0">
+                          <Link href={href} className="block w-full h-full p-4">
+                            <div className="flex items-center gap-3">
+                              <Avatar className="h-10 w-10 border border-border bg-muted rounded-md">
+                                <AvatarImage
+                                  src={
+                                    member.legendNameKey
+                                      ? `/images/legends/avatars/${member.legendNameKey.toLowerCase()}.png`
+                                      : undefined
+                                  }
+                                  alt={member.legendNameKey || 'Legend'}
+                                  className="object-cover object-top"
+                                  loading="lazy"
+                                />
+                                <AvatarFallback className="text-[10px] uppercase font-bold text-muted-foreground rounded-md">
+                                  {fixEncoding(member.name).substring(0, 2)}
+                                </AvatarFallback>
+                              </Avatar>
+                              <span className="font-bold text-lg text-foreground group-hover:text-primary transition-colors">
+                                {fixEncoding(member.name)}
+                              </span>
+                            </div>
+                          </Link>
                         </TableCell>
-                        <TableCell className="text-right text-muted-foreground text-sm hidden sm:table-cell">
-                          {formatJoinedDate(member.joinDate)}
+                        <TableCell className="p-0 text-right font-mono">
+                          <Link href={href} className="block w-full h-full p-4">
+                            {elo === null ? (
+                              <span className="text-muted-foreground">—</span>
+                            ) : (
+                              <div className="flex flex-col items-end leading-tight">
+                                <span className="font-bold">{elo}</span>
+                                {peakElo !== null && (
+                                  <span className="text-xs text-muted-foreground">
+                                    Peak {peakElo}
+                                  </span>
+                                )}
+                              </div>
+                            )}
+                          </Link>
+                        </TableCell>
+                        <TableCell className="p-0 text-right font-mono">
+                          <Link href={href} className="block w-full h-full p-4">
+                            <div className="flex flex-col items-end leading-tight">
+                              <span className="font-bold">
+                                {member.xp.toLocaleString()}
+                              </span>
+                              <span className="text-xs text-muted-foreground">
+                                {contribution.toFixed(1)}%
+                              </span>
+                            </div>
+                          </Link>
+                        </TableCell>
+                        <TableCell className="p-0 text-right text-muted-foreground text-sm hidden sm:table-cell">
+                          <Link href={href} className="block w-full h-full p-4">
+                            {formatJoinedDate(member.joinDate)}
+                          </Link>
                         </TableCell>
                       </TableRow>
                     );

--- a/apps/web/src/components/player/PlayerProfile.tsx
+++ b/apps/web/src/components/player/PlayerProfile.tsx
@@ -3,7 +3,6 @@
 import { useState, useRef } from 'react';
 import useSWR from 'swr';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 import { fetcher } from '@/lib/api';
 import { fixEncoding, timeAgo } from '@/lib/utils';
 import {
@@ -76,7 +75,6 @@ const WinLossBar = ({
 };
 
 export function PlayerProfile({ initialData, id }: PlayerProfileProps) {
-  const router = useRouter();
   const [showAllLegends, setShowAllLegends] = useState(false);
   const [expandedLegendId, setExpandedLegendId] = useState<number | null>(null);
   const [showAllWeapons, setShowAllWeapons] = useState(false);
@@ -800,6 +798,7 @@ export function PlayerProfile({ initialData, id }: PlayerProfileProps) {
                 team.brawlhallaIdOne === idNumber
                   ? team.brawlhallaIdTwo
                   : team.brawlhallaIdOne;
+              const teammateHref = `/player/${teammateId}`;
               const bannerUrl = getRankBanner(team.tier);
 
               const teamNameParts = fixEncoding(team.teamName).split('+');
@@ -813,17 +812,9 @@ export function PlayerProfile({ initialData, id }: PlayerProfileProps) {
                 fixEncoding(team.teamName);
 
               return (
-                <div
+                <Link
                   key={`${team.brawlhallaIdOne}-${team.brawlhallaIdTwo}`}
-                  onClick={() => router.push(`/player/${teammateId}`)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
-                      router.push(`/player/${teammateId}`);
-                    }
-                  }}
-                  role="button"
-                  tabIndex={0}
+                  href={teammateHref}
                   className="group flex items-stretch rounded-xl bg-card border border-border hover:border-primary transition-colors cursor-pointer min-h-36 relative overflow-visible mt-4"
                 >
                   {/* Rank Banner on Left - Bleeding Out */}
@@ -899,7 +890,7 @@ export function PlayerProfile({ initialData, id }: PlayerProfileProps) {
                       </div>
                     </div>
                   </div>
-                </div>
+                </Link>
               );
             })}
           </div>


### PR DESCRIPTION
…for improved accessibility

## Summary

- Replaced router.push with Next Link's - this way you can open pages in a new tab by right clicking, or with ctrl/cmd+click

## Checklist

- [x] I ran `pnpm lint` and fixed new lint issues
- [x] I ran `pnpm typecheck` and fixed TS errors
- [x] I ran `pnpm build` (or validated affected apps/libs)
- [x] If I touched API/worker logic, I verified queue + rate-limit behavior
- [x] If I touched Prisma schema/migrations, I documented migration steps
- [x] If I touched the web UI, I added screenshots (before/after) where relevant

## Notes / Follow-ups

<img width="651" height="141" alt="image" src="https://github.com/user-attachments/assets/1f23583f-7660-413e-af05-14d7f4222127" />
<img width="457" height="198" alt="image" src="https://github.com/user-attachments/assets/e5926c19-2ff7-4010-8339-623e16f72065" />
<img width="388" height="130" alt="image" src="https://github.com/user-attachments/assets/f0a610d8-cef7-4598-b3aa-96003b76c24b" />
<img width="448" height="157" alt="image" src="https://github.com/user-attachments/assets/5d697e48-d627-4515-8036-b62bba735015" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced navigation handling across player leaderboards, search results, clan members, and player teammates for improved user interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->