### PR TITLE
feat: Discord OAuth login (Identity Slice 1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,4 +25,10 @@ TURNSTILE_SECRET_KEY=
 
 # Optional
 CORS_ORIGIN=http://localhost:3001
+WEB_ORIGIN=http://localhost:3001
 PORT=3000
+
+# Discord OAuth (create an app at https://discord.com/developers/applications)
+DISCORD_CLIENT_SECRET=
+DISCORD_REDIRECT_URI=http://localhost:3000/auth/discord/callback
+SESSION_COOKIE_DOMAIN=

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -2,3 +2,10 @@ DATABASE_URL=postgresql://brawltome:brawltome@localhost:5432/brawltome
 REDIS_URL=redis://localhost:6379
 BRAWLHALLA_API_KEY=your-key-here
 CORS_ORIGIN=http://localhost:3001
+WEB_ORIGIN=http://localhost:3001
+
+# Discord OAuth (create an app at https://discord.com/developers/applications)
+DISCORD_CLIENT_ID=
+DISCORD_CLIENT_SECRET=
+DISCORD_REDIRECT_URI=http://localhost:3000/auth/discord/callback
+SESSION_COOKIE_DOMAIN=

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,6 +16,7 @@
     "@brawltome/bhapi": "workspace:*",
     "@brawltome/clan": "workspace:*",
     "@brawltome/database": "workspace:*",
+    "@brawltome/identity": "workspace:*",
     "@brawltome/player": "workspace:*",
     "@brawltome/ranking": "workspace:*",
     "@brawltome/shared": "workspace:*",

--- a/apps/api/src/auth/cookies.ts
+++ b/apps/api/src/auth/cookies.ts
@@ -1,0 +1,54 @@
+// apps/api/src/auth/cookies.ts
+export const SESSION_COOKIE = 'brawltome_session'
+export const OAUTH_STATE_COOKIE = 'brawltome_oauth_state'
+export const OAUTH_STATE_TTL_SEC = 10 * 60 // 10 minutes
+
+const isProd = process.env.NODE_ENV === 'production'
+const sessionCookieDomain = process.env.SESSION_COOKIE_DOMAIN ?? undefined
+
+interface CookieOptions {
+  maxAgeSec: number
+  includeDomain?: boolean
+}
+
+function serialize(name: string, value: string, opts: CookieOptions): string {
+  const parts = [
+    `${name}=${value}`,
+    'Path=/',
+    'HttpOnly',
+    'SameSite=Lax',
+    `Max-Age=${opts.maxAgeSec}`,
+  ]
+  if (isProd) parts.push('Secure')
+  if (opts.includeDomain && sessionCookieDomain) parts.push(`Domain=${sessionCookieDomain}`)
+  return parts.join('; ')
+}
+
+export function buildSessionCookie(rawToken: string, maxAgeSec: number): string {
+  return serialize(SESSION_COOKIE, rawToken, { maxAgeSec, includeDomain: true })
+}
+
+export function clearSessionCookie(): string {
+  return serialize(SESSION_COOKIE, '', { maxAgeSec: 0, includeDomain: true })
+}
+
+export function buildStateCookie(state: string): string {
+  return serialize(OAUTH_STATE_COOKIE, state, { maxAgeSec: OAUTH_STATE_TTL_SEC })
+}
+
+export function clearStateCookie(): string {
+  return serialize(OAUTH_STATE_COOKIE, '', { maxAgeSec: 0 })
+}
+
+export function parseCookies(header: string | null | undefined): Record<string, string> {
+  if (!header) return {}
+  const out: Record<string, string> = {}
+  for (const part of header.split(';')) {
+    const eq = part.indexOf('=')
+    if (eq < 0) continue
+    const k = part.slice(0, eq).trim()
+    const v = part.slice(eq + 1).trim()
+    if (k) out[k] = decodeURIComponent(v)
+  }
+  return out
+}

--- a/apps/api/src/auth/cookies.ts
+++ b/apps/api/src/auth/cookies.ts
@@ -13,7 +13,7 @@ interface CookieOptions {
 
 function serialize(name: string, value: string, opts: CookieOptions): string {
   const parts = [
-    `${name}=${value}`,
+    `${name}=${encodeURIComponent(value)}`,
     'Path=/',
     'HttpOnly',
     'SameSite=Lax',
@@ -48,7 +48,13 @@ export function parseCookies(header: string | null | undefined): Record<string, 
     if (eq < 0) continue
     const k = part.slice(0, eq).trim()
     const v = part.slice(eq + 1).trim()
-    if (k) out[k] = decodeURIComponent(v)
+    if (k) {
+      try {
+        out[k] = decodeURIComponent(v)
+      } catch {
+        out[k] = v
+      }
+    }
   }
   return out
 }

--- a/apps/api/src/auth/discord.ts
+++ b/apps/api/src/auth/discord.ts
@@ -38,6 +38,7 @@ export async function exchangeCode(params: ExchangeCodeParams): Promise<{ access
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: body.toString(),
+    signal: AbortSignal.timeout(10_000),
   })
 
   if (!res.ok) {
@@ -59,6 +60,7 @@ export interface DiscordUserProfile {
 export async function fetchDiscordUser(accessToken: string): Promise<DiscordUserProfile> {
   const res = await fetch(DISCORD_USER_URL, {
     headers: { Authorization: `Bearer ${accessToken}` },
+    signal: AbortSignal.timeout(10_000),
   })
 
   if (!res.ok) {

--- a/apps/api/src/auth/discord.ts
+++ b/apps/api/src/auth/discord.ts
@@ -1,0 +1,75 @@
+const DISCORD_AUTHORIZE_URL = 'https://discord.com/api/oauth2/authorize'
+const DISCORD_TOKEN_URL = 'https://discord.com/api/oauth2/token'
+const DISCORD_USER_URL = 'https://discord.com/api/users/@me'
+
+export interface BuildAuthorizeUrlParams {
+  clientId: string
+  redirectUri: string
+  state: string
+}
+
+export function buildAuthorizeUrl(params: BuildAuthorizeUrlParams): string {
+  const url = new URL(DISCORD_AUTHORIZE_URL)
+  url.searchParams.set('client_id', params.clientId)
+  url.searchParams.set('redirect_uri', params.redirectUri)
+  url.searchParams.set('response_type', 'code')
+  url.searchParams.set('scope', 'identify')
+  url.searchParams.set('state', params.state)
+  return url.toString()
+}
+
+export interface ExchangeCodeParams {
+  clientId: string
+  clientSecret: string
+  redirectUri: string
+  code: string
+}
+
+export async function exchangeCode(params: ExchangeCodeParams): Promise<{ accessToken: string }> {
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code: params.code,
+    redirect_uri: params.redirectUri,
+    client_id: params.clientId,
+    client_secret: params.clientSecret,
+  })
+
+  const res = await fetch(DISCORD_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  })
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`Discord token exchange failed: ${res.status} ${text}`)
+  }
+
+  const data = (await res.json()) as { access_token?: string }
+  if (!data.access_token) throw new Error('Discord token exchange returned no access_token')
+  return { accessToken: data.access_token }
+}
+
+export interface DiscordUserProfile {
+  discordId: string
+  username: string
+  avatarHash: string | null
+}
+
+export async function fetchDiscordUser(accessToken: string): Promise<DiscordUserProfile> {
+  const res = await fetch(DISCORD_USER_URL, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  })
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`Discord user fetch failed: ${res.status} ${text}`)
+  }
+
+  const data = (await res.json()) as { id: string; username: string; avatar: string | null }
+  return {
+    discordId: data.id,
+    username: data.username,
+    avatarHash: data.avatar ?? null,
+  }
+}

--- a/apps/api/src/auth/routes.ts
+++ b/apps/api/src/auth/routes.ts
@@ -1,0 +1,112 @@
+import { randomBytes, timingSafeEqual } from 'node:crypto'
+import type { SessionRepo, UserRepo } from '@brawltome/identity'
+import { SESSION_TTL_MS, signInWithDiscord, signOut } from '@brawltome/identity'
+import { Hono } from 'hono'
+import {
+  OAUTH_STATE_COOKIE,
+  SESSION_COOKIE,
+  buildSessionCookie,
+  buildStateCookie,
+  clearSessionCookie,
+  clearStateCookie,
+  parseCookies,
+} from './cookies'
+import { buildAuthorizeUrl, exchangeCode, fetchDiscordUser } from './discord'
+
+export interface AuthConfig {
+  discordClientId: string
+  discordClientSecret: string
+  discordRedirectUri: string
+  webOrigin: string
+}
+
+export interface CreateAuthRoutesDeps {
+  userRepo: UserRepo
+  sessionRepo: SessionRepo
+  config: AuthConfig
+}
+
+export function createAuthRoutes(deps: CreateAuthRoutesDeps): Hono {
+  const app = new Hono()
+  const { userRepo, sessionRepo, config } = deps
+
+  app.get('/discord/login', (c) => {
+    const state = randomBytes(32).toString('base64url')
+    c.header('Set-Cookie', buildStateCookie(state))
+    return c.redirect(
+      buildAuthorizeUrl({
+        clientId: config.discordClientId,
+        redirectUri: config.discordRedirectUri,
+        state,
+      }),
+    )
+  })
+
+  app.get('/discord/callback', async (c) => {
+    const cookies = parseCookies(c.req.header('cookie'))
+    const expected = cookies[OAUTH_STATE_COOKIE]
+    const provided = c.req.query('state')
+    const code = c.req.query('code')
+
+    const stateValid =
+      !!expected &&
+      !!provided &&
+      expected.length === provided.length &&
+      timingSafeEqual(Buffer.from(expected), Buffer.from(provided))
+
+    if (!stateValid || !code) {
+      c.header('Set-Cookie', clearStateCookie())
+      return c.redirect(`${config.webOrigin}/account?error=state`)
+    }
+
+    c.header('Set-Cookie', clearStateCookie())
+
+    let accessToken: string
+    try {
+      const exchange = await exchangeCode({
+        clientId: config.discordClientId,
+        clientSecret: config.discordClientSecret,
+        redirectUri: config.discordRedirectUri,
+        code,
+      })
+      accessToken = exchange.accessToken
+    } catch (err) {
+      console.error('[auth] discord token exchange failed', err)
+      return c.redirect(`${config.webOrigin}/account?error=discord`)
+    }
+
+    let profile: Awaited<ReturnType<typeof fetchDiscordUser>>
+    try {
+      profile = await fetchDiscordUser(accessToken)
+    } catch (err) {
+      console.error('[auth] discord user fetch failed', err)
+      return c.redirect(`${config.webOrigin}/account?error=discord`)
+    }
+
+    try {
+      const { rawToken } = await signInWithDiscord({ userRepo, sessionRepo }, profile)
+      c.header('Set-Cookie', buildSessionCookie(rawToken, SESSION_TTL_MS / 1000), { append: true })
+    } catch (err) {
+      console.error('[auth] signInWithDiscord failed', err)
+      return c.redirect(`${config.webOrigin}/account?error=server`)
+    }
+
+    return c.redirect(`${config.webOrigin}/`)
+  })
+
+  app.post('/signout', async (c) => {
+    const cookies = parseCookies(c.req.header('cookie'))
+    const raw = cookies[SESSION_COOKIE]
+    if (raw) {
+      try {
+        await signOut({ sessionRepo }, raw)
+      } catch (err) {
+        console.error('[auth] signOut failed', err)
+      }
+    }
+    c.header('Set-Cookie', clearSessionCookie())
+    return c.body(null, 204)
+  })
+
+  return app
+}

--- a/apps/api/src/router/identity.router.ts
+++ b/apps/api/src/router/identity.router.ts
@@ -11,6 +11,7 @@ export const identityRouter = router({
       id: ctx.user.id,
       username: primaryAccount.username,
       avatarUrl,
+      createdAt: ctx.user.createdAt,
     }
   }),
 })

--- a/apps/api/src/router/identity.router.ts
+++ b/apps/api/src/router/identity.router.ts
@@ -1,0 +1,16 @@
+import { publicProcedure, router } from '../trpc/trpc'
+
+export const identityRouter = router({
+  me: publicProcedure.query(({ ctx }) => {
+    if (!ctx.user) return null
+    const { primaryAccount } = ctx.user
+    const avatarUrl = primaryAccount.avatarHash
+      ? `https://cdn.discordapp.com/avatars/${primaryAccount.providerAccountId}/${primaryAccount.avatarHash}.png`
+      : null
+    return {
+      id: ctx.user.id,
+      username: primaryAccount.username,
+      avatarUrl,
+    }
+  }),
+})

--- a/apps/api/src/router/index.ts
+++ b/apps/api/src/router/index.ts
@@ -1,5 +1,6 @@
 import { router } from '../trpc/trpc'
 import { clanRouter } from './clan.router'
+import { identityRouter } from './identity.router'
 import { leaderboardRouter } from './leaderboard.router'
 import { playerRouter } from './player.router'
 import { searchRouter } from './search.router'
@@ -11,6 +12,7 @@ export const appRouter = router({
   clan: clanRouter,
   search: searchRouter,
   leaderboard: leaderboardRouter,
+  identity: identityRouter,
 })
 
 export type AppRouter = typeof appRouter

--- a/apps/api/src/serve.ts
+++ b/apps/api/src/serve.ts
@@ -46,7 +46,8 @@ const authConfig = {
 app.use(
   '/*',
   cors({
-    origin: corsOrigins,
+    origin: (origin) => (corsOrigins.includes(origin) ? origin : null),
+    credentials: true,
   }),
 )
 

--- a/apps/api/src/serve.ts
+++ b/apps/api/src/serve.ts
@@ -27,7 +27,18 @@ const rankingRepo = createRankingRepo(db)
 const userRepo = createUserRepo(db)
 const sessionRepo = createSessionRepo(db)
 
-const sharedCtx = { db, redis, rankedQueue, statsQueue, clanQueue, playerRepo, clanRepo, rankingRepo, userRepo, sessionRepo }
+const sharedCtx = {
+  db,
+  redis,
+  rankedQueue,
+  statsQueue,
+  clanQueue,
+  playerRepo,
+  clanRepo,
+  rankingRepo,
+  userRepo,
+  sessionRepo,
+}
 
 const app = new Hono()
 

--- a/apps/api/src/serve.ts
+++ b/apps/api/src/serve.ts
@@ -1,5 +1,6 @@
 import { createClanRepo } from '@brawltome/clan'
 import { db } from '@brawltome/database'
+import { SESSION_TTL_MS, createSessionRepo, createUserRepo, getCurrentUser } from '@brawltome/identity'
 import { DEDUP_TTL_RANKED_SEC, DEDUP_TTL_STATS_SEC, createPlayerRepo, getPlayer } from '@brawltome/player'
 import { createRankingRepo } from '@brawltome/ranking'
 import { TIERED_TTL, createQueue, dedupKey, getLegendById, initGameData, tryDedup } from '@brawltome/shared'
@@ -7,6 +8,8 @@ import { trpcServer } from '@hono/trpc-server'
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 import Redis from 'ioredis'
+import { SESSION_COOKIE, buildSessionCookie, parseCookies } from './auth/cookies'
+import { createAuthRoutes } from './auth/routes'
 import { appRouter } from './router'
 
 const redis = new Redis(process.env.REDIS_URL ?? 'redis://localhost:6379')
@@ -21,8 +24,10 @@ const clanQueue = createQueue<{ clanId: number }>(redis, 'refresh-clan', async (
 const playerRepo = createPlayerRepo(db)
 const clanRepo = createClanRepo(db)
 const rankingRepo = createRankingRepo(db)
+const userRepo = createUserRepo(db)
+const sessionRepo = createSessionRepo(db)
 
-const sharedCtx = { db, redis, rankedQueue, statsQueue, clanQueue, playerRepo, clanRepo, rankingRepo }
+const sharedCtx = { db, redis, rankedQueue, statsQueue, clanQueue, playerRepo, clanRepo, rankingRepo, userRepo, sessionRepo }
 
 const app = new Hono()
 
@@ -31,6 +36,13 @@ const corsOrigins = (process.env.CORS_ORIGIN ?? 'http://localhost:3001')
   .map((origin) => origin.trim())
   .filter((origin) => origin.length > 0)
 
+const authConfig = {
+  discordClientId: process.env.DISCORD_CLIENT_ID ?? '',
+  discordClientSecret: process.env.DISCORD_CLIENT_SECRET ?? '',
+  discordRedirectUri: process.env.DISCORD_REDIRECT_URI ?? 'http://localhost:3000/auth/discord/callback',
+  webOrigin: process.env.WEB_ORIGIN ?? corsOrigins[0] ?? 'http://localhost:3001',
+}
+
 app.use(
   '/*',
   cors({
@@ -38,11 +50,13 @@ app.use(
   }),
 )
 
+app.route('/auth', createAuthRoutes({ userRepo, sessionRepo, config: authConfig }))
+
 app.use(
   '/trpc/*',
   trpcServer({
     router: appRouter,
-    createContext: (_opts, c) => {
+    createContext: async (_opts, c) => {
       const clientIp =
         c.req.header('x-client-ip') ??
         c.req.header('cf-connecting-ip') ??
@@ -54,7 +68,23 @@ app.use(
           ua,
         )
       const internalSecret = c.req.header('x-internal-secret') ?? undefined
-      return { ...sharedCtx, clientIp, isBot, internalSecret } as unknown as Record<string, unknown>
+
+      const cookies = parseCookies(c.req.header('cookie'))
+      const rawToken = cookies[SESSION_COOKIE] ?? null
+      const current = await getCurrentUser({ userRepo, sessionRepo }, rawToken)
+
+      if (current?.extended && rawToken) {
+        c.header('Set-Cookie', buildSessionCookie(rawToken, SESSION_TTL_MS / 1000), { append: true })
+      }
+
+      return {
+        ...sharedCtx,
+        clientIp,
+        isBot,
+        internalSecret,
+        user: current?.user ?? null,
+        session: current?.session ?? null,
+      } as unknown as Record<string, unknown>
     },
   }),
 )

--- a/apps/api/src/trpc/context.ts
+++ b/apps/api/src/trpc/context.ts
@@ -1,5 +1,6 @@
 import type { ClanRepo } from '@brawltome/clan'
 import type { Database } from '@brawltome/database'
+import type { Session, SessionRepo, UserRepo, UserWithPrimaryAccount } from '@brawltome/identity'
 import type { PlayerRepo } from '@brawltome/player'
 import type { RankingRepo } from '@brawltome/ranking'
 import type { Queue } from '@brawltome/shared'
@@ -14,7 +15,11 @@ export interface Context {
   playerRepo: PlayerRepo
   clanRepo: ClanRepo
   rankingRepo: RankingRepo
+  userRepo: UserRepo
+  sessionRepo: SessionRepo
   clientIp: string
   isBot: boolean
   internalSecret: string | undefined
+  user: UserWithPrimaryAccount | null
+  session: Session | null
 }

--- a/apps/api/src/trpc/trpc.ts
+++ b/apps/api/src/trpc/trpc.ts
@@ -24,9 +24,26 @@ export function createInternalMiddleware(expectedSecret: string) {
   })
 }
 
+export function createProtectedMiddleware() {
+  return t.middleware(({ ctx, next }) => {
+    const anyCtx = ctx as unknown as { user: unknown }
+    if (!anyCtx.user) {
+      throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Sign in required' })
+    }
+    return next({
+      ctx: {
+        ...ctx,
+        user: anyCtx.user as NonNullable<typeof anyCtx.user>,
+      },
+    })
+  })
+}
+
 const internalSecret = process.env.INTERNAL_API_SECRET ?? ''
 const internalMiddleware = createInternalMiddleware(internalSecret)
+const protectedMiddleware = createProtectedMiddleware()
 
 export const router = t.router
 export const publicProcedure = t.procedure
 export const internalProcedure = t.procedure.use(internalMiddleware)
+export const protectedProcedure = t.procedure.use(protectedMiddleware)

--- a/apps/api/src/trpc/trpc.ts
+++ b/apps/api/src/trpc/trpc.ts
@@ -26,14 +26,13 @@ export function createInternalMiddleware(expectedSecret: string) {
 
 export function createProtectedMiddleware() {
   return t.middleware(({ ctx, next }) => {
-    const anyCtx = ctx as unknown as { user: unknown }
-    if (!anyCtx.user) {
+    if (!ctx.user) {
       throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Sign in required' })
     }
     return next({
       ctx: {
         ...ctx,
-        user: anyCtx.user as NonNullable<typeof anyCtx.user>,
+        user: ctx.user,
       },
     })
   })

--- a/apps/api/tests/identity/auth-routes.test.ts
+++ b/apps/api/tests/identity/auth-routes.test.ts
@@ -133,10 +133,7 @@ describe('GET /auth/discord/callback', () => {
         return new Response(JSON.stringify({ access_token: 'at' }), { status: 200 })
       }
       if (u.includes('/users/@me')) {
-        return new Response(
-          JSON.stringify({ id: 'discord-42', username: 'coolguy', avatar: 'abc' }),
-          { status: 200 },
-        )
+        return new Response(JSON.stringify({ id: 'discord-42', username: 'coolguy', avatar: 'abc' }), { status: 200 })
       }
       return new Response('not mocked', { status: 500 })
     }) as unknown as typeof fetch

--- a/apps/api/tests/identity/auth-routes.test.ts
+++ b/apps/api/tests/identity/auth-routes.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import type { SessionRepo, UserRepo, UserWithPrimaryAccount } from '@brawltome/identity'
+import { Hono } from 'hono'
+import { createAuthRoutes } from '../../src/auth/routes'
+
+const originalFetch = globalThis.fetch
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+function makeUser(): UserWithPrimaryAccount {
+  const now = new Date()
+  return {
+    id: 'user-1',
+    createdAt: now,
+    updatedAt: now,
+    primaryAccount: {
+      userId: 'user-1',
+      provider: 'discord',
+      providerAccountId: 'discord-42',
+      username: 'coolguy',
+      avatarHash: 'abc',
+      refreshToken: null,
+      createdAt: now,
+      updatedAt: now,
+    },
+  }
+}
+
+function makeFakes() {
+  const users: UserWithPrimaryAccount[] = []
+  const sessions: Array<{ id: string; userId: string; expiresAt: Date; createdAt: Date }> = []
+
+  const userRepo: UserRepo = {
+    async findByDiscordId() {
+      return null
+    },
+    async findById(id) {
+      return users.find((u) => u.id === id) ?? null
+    },
+    async upsertDiscordUser(profile) {
+      let u = users[0]
+      if (!u) {
+        u = makeUser()
+        u.primaryAccount.providerAccountId = profile.discordId
+        u.primaryAccount.username = profile.username
+        u.primaryAccount.avatarHash = profile.avatarHash
+        users.push(u)
+      }
+      return u
+    },
+  }
+  const sessionRepo: SessionRepo = {
+    async create(row) {
+      const full = { ...row, createdAt: new Date() }
+      sessions.push(full)
+      return full
+    },
+    async findById(id) {
+      return sessions.find((s) => s.id === id) ?? null
+    },
+    async deleteById(id) {
+      const i = sessions.findIndex((s) => s.id === id)
+      if (i >= 0) sessions.splice(i, 1)
+    },
+    async extend() {},
+    async deleteExpired() {
+      return 0
+    },
+  }
+
+  return { userRepo, sessionRepo, users, sessions }
+}
+
+function buildApp(fakes: ReturnType<typeof makeFakes>) {
+  const app = new Hono()
+  app.route(
+    '/auth',
+    createAuthRoutes({
+      userRepo: fakes.userRepo,
+      sessionRepo: fakes.sessionRepo,
+      config: {
+        discordClientId: 'cid',
+        discordClientSecret: 'csecret',
+        discordRedirectUri: 'http://localhost:3000/auth/discord/callback',
+        webOrigin: 'http://localhost:3001',
+      },
+    }),
+  )
+  return app
+}
+
+describe('GET /auth/discord/login', () => {
+  it('sets a state cookie and redirects to discord', async () => {
+    const fakes = makeFakes()
+    const app = buildApp(fakes)
+
+    const res = await app.request('/auth/discord/login')
+    expect(res.status).toBe(302)
+    const location = res.headers.get('location') ?? ''
+    expect(location).toStartWith('https://discord.com/api/oauth2/authorize')
+    const setCookie = res.headers.get('set-cookie') ?? ''
+    expect(setCookie).toContain('brawltome_oauth_state=')
+    expect(setCookie).toContain('HttpOnly')
+    expect(setCookie).toContain('SameSite=Lax')
+
+    // state param in the redirect must match the cookie value
+    const state = new URL(location).searchParams.get('state')
+    expect(state).toBeTruthy()
+    expect(setCookie).toContain(`brawltome_oauth_state=${state}`)
+  })
+})
+
+describe('GET /auth/discord/callback', () => {
+  it('errors redirects when state is missing or mismatched', async () => {
+    const fakes = makeFakes()
+    const app = buildApp(fakes)
+
+    const res = await app.request('/auth/discord/callback?code=x&state=wrong', {
+      headers: { cookie: 'brawltome_oauth_state=expected' },
+    })
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe('http://localhost:3001/account?error=state')
+  })
+
+  it('exchanges code, upserts user, creates session, sets cookie, and redirects', async () => {
+    const fakes = makeFakes()
+    const app = buildApp(fakes)
+
+    globalThis.fetch = mock(async (url) => {
+      const u = String(url)
+      if (u.includes('/oauth2/token')) {
+        return new Response(JSON.stringify({ access_token: 'at' }), { status: 200 })
+      }
+      if (u.includes('/users/@me')) {
+        return new Response(
+          JSON.stringify({ id: 'discord-42', username: 'coolguy', avatar: 'abc' }),
+          { status: 200 },
+        )
+      }
+      return new Response('not mocked', { status: 500 })
+    }) as unknown as typeof fetch
+
+    const res = await app.request('/auth/discord/callback?code=the-code&state=expected', {
+      headers: { cookie: 'brawltome_oauth_state=expected' },
+    })
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe('http://localhost:3001/')
+
+    // Session cookie set
+    const setCookie = res.headers.get('set-cookie') ?? ''
+    expect(setCookie).toContain('brawltome_session=')
+    expect(setCookie).toContain('HttpOnly')
+
+    // User + session created
+    expect(fakes.users).toHaveLength(1)
+    expect(fakes.sessions).toHaveLength(1)
+  })
+
+  it('redirects to the discord error state on upstream failure', async () => {
+    const fakes = makeFakes()
+    const app = buildApp(fakes)
+
+    globalThis.fetch = mock(async () => new Response('nope', { status: 400 })) as unknown as typeof fetch
+
+    const res = await app.request('/auth/discord/callback?code=x&state=expected', {
+      headers: { cookie: 'brawltome_oauth_state=expected' },
+    })
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe('http://localhost:3001/account?error=discord')
+  })
+})
+
+describe('POST /auth/signout', () => {
+  it('deletes the session and clears the cookie', async () => {
+    const fakes = makeFakes()
+    const app = buildApp(fakes)
+    const { hashSessionToken } = await import('@brawltome/identity')
+    const raw = 'raw-token'
+    fakes.sessions.push({
+      id: hashSessionToken(raw),
+      userId: 'user-1',
+      expiresAt: new Date(Date.now() + 1_000_000),
+      createdAt: new Date(),
+    })
+
+    const res = await app.request('/auth/signout', {
+      method: 'POST',
+      headers: { cookie: `brawltome_session=${raw}` },
+    })
+    expect(res.status).toBe(204)
+    expect(fakes.sessions).toHaveLength(0)
+    const setCookie = res.headers.get('set-cookie') ?? ''
+    expect(setCookie).toContain('brawltome_session=')
+    expect(setCookie).toContain('Max-Age=0')
+  })
+
+  it('returns 204 even when there is no cookie', async () => {
+    const fakes = makeFakes()
+    const app = buildApp(fakes)
+    const res = await app.request('/auth/signout', { method: 'POST' })
+    expect(res.status).toBe(204)
+  })
+})

--- a/apps/api/tests/identity/discord-client.test.ts
+++ b/apps/api/tests/identity/discord-client.test.ts
@@ -48,9 +48,7 @@ describe('exchangeCode', () => {
 
   it('throws on non-200 responses', async () => {
     globalThis.fetch = mock(async () => new Response('nope', { status: 400 })) as unknown as typeof fetch
-    await expect(
-      exchangeCode({ clientId: 'c', clientSecret: 's', redirectUri: 'r', code: 'x' }),
-    ).rejects.toThrow()
+    await expect(exchangeCode({ clientId: 'c', clientSecret: 's', redirectUri: 'r', code: 'x' })).rejects.toThrow()
   })
 })
 
@@ -74,8 +72,7 @@ describe('fetchDiscordUser', () => {
 
   it('tolerates a null avatar', async () => {
     globalThis.fetch = mock(
-      async () =>
-        new Response(JSON.stringify({ id: '42', username: 'x', avatar: null }), { status: 200 }),
+      async () => new Response(JSON.stringify({ id: '42', username: 'x', avatar: null }), { status: 200 }),
     ) as unknown as typeof fetch
     const result = await fetchDiscordUser('tok')
     expect(result.avatarHash).toBeNull()

--- a/apps/api/tests/identity/discord-client.test.ts
+++ b/apps/api/tests/identity/discord-client.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { buildAuthorizeUrl, exchangeCode, fetchDiscordUser } from '../../src/auth/discord'
+
+const originalFetch = globalThis.fetch
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe('buildAuthorizeUrl', () => {
+  it('includes all required query params', () => {
+    const url = buildAuthorizeUrl({
+      clientId: 'cid',
+      redirectUri: 'http://localhost:3000/auth/discord/callback',
+      state: 'abc123',
+    })
+    const u = new URL(url)
+    expect(u.origin).toBe('https://discord.com')
+    expect(u.pathname).toBe('/api/oauth2/authorize')
+    expect(u.searchParams.get('client_id')).toBe('cid')
+    expect(u.searchParams.get('redirect_uri')).toBe('http://localhost:3000/auth/discord/callback')
+    expect(u.searchParams.get('response_type')).toBe('code')
+    expect(u.searchParams.get('scope')).toBe('identify')
+    expect(u.searchParams.get('state')).toBe('abc123')
+  })
+})
+
+describe('exchangeCode', () => {
+  it('POSTs form-encoded credentials and returns the access_token', async () => {
+    let capturedBody: string | null = null
+    globalThis.fetch = mock(async (_url, init) => {
+      capturedBody = init?.body as string
+      return new Response(JSON.stringify({ access_token: 'tok', token_type: 'Bearer' }), { status: 200 })
+    }) as unknown as typeof fetch
+
+    const result = await exchangeCode({
+      clientId: 'cid',
+      clientSecret: 'csecret',
+      redirectUri: 'http://localhost:3000/auth/discord/callback',
+      code: 'the-code',
+    })
+
+    expect(result).toEqual({ accessToken: 'tok' })
+    expect(capturedBody).toContain('grant_type=authorization_code')
+    expect(capturedBody).toContain('code=the-code')
+    expect(capturedBody).toContain('client_id=cid')
+    expect(capturedBody).toContain('client_secret=csecret')
+  })
+
+  it('throws on non-200 responses', async () => {
+    globalThis.fetch = mock(async () => new Response('nope', { status: 400 })) as unknown as typeof fetch
+    await expect(
+      exchangeCode({ clientId: 'c', clientSecret: 's', redirectUri: 'r', code: 'x' }),
+    ).rejects.toThrow()
+  })
+})
+
+describe('fetchDiscordUser', () => {
+  it('returns the mapped profile', async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response(
+          JSON.stringify({
+            id: '42',
+            username: 'coolguy',
+            avatar: 'abc',
+          }),
+          { status: 200 },
+        ),
+    ) as unknown as typeof fetch
+
+    const result = await fetchDiscordUser('tok')
+    expect(result).toEqual({ discordId: '42', username: 'coolguy', avatarHash: 'abc' })
+  })
+
+  it('tolerates a null avatar', async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response(JSON.stringify({ id: '42', username: 'x', avatar: null }), { status: 200 }),
+    ) as unknown as typeof fetch
+    const result = await fetchDiscordUser('tok')
+    expect(result.avatarHash).toBeNull()
+  })
+
+  it('throws on non-200 responses', async () => {
+    globalThis.fetch = mock(async () => new Response('nope', { status: 401 })) as unknown as typeof fetch
+    await expect(fetchDiscordUser('tok')).rejects.toThrow()
+  })
+})

--- a/apps/api/tests/identity/get-current-user.test.ts
+++ b/apps/api/tests/identity/get-current-user.test.ts
@@ -107,10 +107,11 @@ describe('getCurrentUser', () => {
 
   it('extends the session when it is within the threshold window', async () => {
     const raw = 'raw-token'
+    const before = Date.now()
     const nearExpiry: Session = {
       id: hashSessionToken(raw),
       userId: 'user-1',
-      // 3 days out — inside the 7-day extend threshold
+      // 3 days out, inside the 7-day extend threshold
       expiresAt: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000),
       createdAt: new Date(),
     }
@@ -119,7 +120,7 @@ describe('getCurrentUser', () => {
 
     expect(result?.extended).toBe(true)
     const extended = sessions[0].expiresAt.getTime()
-    expect(extended - Date.now()).toBeGreaterThanOrEqual(SESSION_TTL_MS - 1000)
+    expect(extended - before).toBeGreaterThanOrEqual(SESSION_TTL_MS - 1000)
   })
 })
 

--- a/apps/api/tests/identity/get-current-user.test.ts
+++ b/apps/api/tests/identity/get-current-user.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  SESSION_EXTEND_THRESHOLD_MS,
+  SESSION_TTL_MS,
+  getCurrentUser,
+  hashSessionToken,
+  signOut,
+} from '@brawltome/identity'
+import type { Session, SessionRepo, UserRepo, UserWithPrimaryAccount } from '@brawltome/identity'
+
+function makeUser(id = 'user-1'): UserWithPrimaryAccount {
+  const now = new Date()
+  return {
+    id,
+    createdAt: now,
+    updatedAt: now,
+    primaryAccount: {
+      userId: id,
+      provider: 'discord',
+      providerAccountId: '12345',
+      username: 'coolguy',
+      avatarHash: null,
+      refreshToken: null,
+      createdAt: now,
+      updatedAt: now,
+    },
+  }
+}
+
+function makeFakes(initialSessions: Session[] = [], users: UserWithPrimaryAccount[] = [makeUser()]) {
+  const sessions = [...initialSessions]
+  const userRepo: UserRepo = {
+    async findByDiscordId() {
+      return null
+    },
+    async findById(id) {
+      return users.find((u) => u.id === id) ?? null
+    },
+    async upsertDiscordUser() {
+      throw new Error('not used')
+    },
+  }
+  const sessionRepo: SessionRepo = {
+    async create(row) {
+      const full: Session = { ...row, createdAt: new Date() }
+      sessions.push(full)
+      return full
+    },
+    async findById(id) {
+      return sessions.find((s) => s.id === id) ?? null
+    },
+    async deleteById(id) {
+      const i = sessions.findIndex((s) => s.id === id)
+      if (i >= 0) sessions.splice(i, 1)
+    },
+    async extend(id, expiresAt) {
+      const row = sessions.find((s) => s.id === id)
+      if (row) row.expiresAt = expiresAt
+    },
+    async deleteExpired() {
+      return 0
+    },
+  }
+  return { userRepo, sessionRepo, sessions }
+}
+
+describe('getCurrentUser', () => {
+  it('returns null when there is no token', async () => {
+    const { userRepo, sessionRepo } = makeFakes()
+    const result = await getCurrentUser({ userRepo, sessionRepo }, null)
+    expect(result).toBeNull()
+  })
+
+  it('returns null when the token does not match any session', async () => {
+    const { userRepo, sessionRepo } = makeFakes()
+    const result = await getCurrentUser({ userRepo, sessionRepo }, 'unknown-token')
+    expect(result).toBeNull()
+  })
+
+  it('returns null when the session is expired', async () => {
+    const raw = 'raw-token'
+    const expired: Session = {
+      id: hashSessionToken(raw),
+      userId: 'user-1',
+      expiresAt: new Date(Date.now() - 1000),
+      createdAt: new Date(),
+    }
+    const { userRepo, sessionRepo } = makeFakes([expired])
+    const result = await getCurrentUser({ userRepo, sessionRepo }, raw)
+    expect(result).toBeNull()
+  })
+
+  it('returns the user when the session is valid', async () => {
+    const raw = 'raw-token'
+    const valid: Session = {
+      id: hashSessionToken(raw),
+      userId: 'user-1',
+      expiresAt: new Date(Date.now() + SESSION_TTL_MS),
+      createdAt: new Date(),
+    }
+    const { userRepo, sessionRepo } = makeFakes([valid])
+    const result = await getCurrentUser({ userRepo, sessionRepo }, raw)
+    expect(result).not.toBeNull()
+    expect(result?.user.id).toBe('user-1')
+    expect(result?.extended).toBe(false)
+  })
+
+  it('extends the session when it is within the threshold window', async () => {
+    const raw = 'raw-token'
+    const nearExpiry: Session = {
+      id: hashSessionToken(raw),
+      userId: 'user-1',
+      // 3 days out — inside the 7-day extend threshold
+      expiresAt: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000),
+      createdAt: new Date(),
+    }
+    const { userRepo, sessionRepo, sessions } = makeFakes([nearExpiry])
+    const result = await getCurrentUser({ userRepo, sessionRepo }, raw)
+
+    expect(result?.extended).toBe(true)
+    const extended = sessions[0].expiresAt.getTime()
+    expect(extended - Date.now()).toBeGreaterThanOrEqual(SESSION_TTL_MS - 1000)
+  })
+})
+
+describe('signOut', () => {
+  it('deletes the session row for the given raw token', async () => {
+    const raw = 'raw-token'
+    const row: Session = {
+      id: hashSessionToken(raw),
+      userId: 'user-1',
+      expiresAt: new Date(Date.now() + SESSION_TTL_MS),
+      createdAt: new Date(),
+    }
+    const { sessionRepo, sessions } = makeFakes([row])
+    await signOut({ sessionRepo }, raw)
+    expect(sessions).toHaveLength(0)
+  })
+
+  it('is a no-op for unknown tokens', async () => {
+    const { sessionRepo } = makeFakes()
+    await signOut({ sessionRepo }, 'whatever')
+  })
+})

--- a/apps/api/tests/identity/me-query.test.ts
+++ b/apps/api/tests/identity/me-query.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'bun:test'
+import type { UserWithPrimaryAccount } from '@brawltome/identity'
+import { initTRPC } from '@trpc/server'
+import superjson from 'superjson'
+import { identityRouter } from '../../src/router/identity.router'
+
+const t = initTRPC.context<{ user: UserWithPrimaryAccount | null }>().create({ transformer: superjson })
+const caller = t.createCallerFactory(identityRouter as unknown as ReturnType<typeof t.router>)
+
+function makeUser(): UserWithPrimaryAccount {
+  const now = new Date()
+  return {
+    id: 'user-1',
+    createdAt: now,
+    updatedAt: now,
+    primaryAccount: {
+      userId: 'user-1',
+      provider: 'discord',
+      providerAccountId: 'discord-42',
+      username: 'coolguy',
+      avatarHash: 'abc',
+      refreshToken: null,
+      createdAt: now,
+      updatedAt: now,
+    },
+  }
+}
+
+describe('identity.me', () => {
+  it('returns null for anonymous callers', async () => {
+    const result = await (caller({ user: null }) as { me: () => Promise<unknown> }).me()
+    expect(result).toBeNull()
+  })
+
+  it('returns the serialized user for signed-in callers', async () => {
+    const user = makeUser()
+    const result = (await (caller({ user }) as { me: () => Promise<unknown> }).me()) as {
+      id: string
+      username: string
+      avatarUrl: string | null
+    } | null
+    expect(result).not.toBeNull()
+    expect(result?.id).toBe('user-1')
+    expect(result?.username).toBe('coolguy')
+    expect(result?.avatarUrl).toBe('https://cdn.discordapp.com/avatars/discord-42/abc.png')
+  })
+
+  it('returns a null avatarUrl when the account has no avatarHash', async () => {
+    const user = makeUser()
+    user.primaryAccount.avatarHash = null
+    const result = (await (caller({ user }) as { me: () => Promise<unknown> }).me()) as {
+      avatarUrl: string | null
+    } | null
+    expect(result?.avatarUrl).toBeNull()
+  })
+})

--- a/apps/api/tests/identity/protected-procedure.test.ts
+++ b/apps/api/tests/identity/protected-procedure.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'bun:test'
+import { TRPCError, initTRPC } from '@trpc/server'
+import superjson from 'superjson'
+import { createProtectedMiddleware } from '../../src/trpc/trpc'
+
+interface TestCtx {
+  user: { id: string } | null
+}
+
+const t = initTRPC.context<TestCtx>().create({ transformer: superjson })
+const middleware = createProtectedMiddleware()
+const procedure = t.procedure.use(middleware)
+const router = t.router({ test: procedure.query(({ ctx }) => ctx.user.id) })
+const caller = t.createCallerFactory(router)
+
+describe('protectedProcedure', () => {
+  it('allows requests with a user', async () => {
+    const result = await caller({ user: { id: 'u1' } }).test()
+    expect(result).toBe('u1')
+  })
+
+  it('rejects anonymous requests with UNAUTHORIZED', async () => {
+    try {
+      await caller({ user: null }).test()
+      throw new Error('should have thrown')
+    } catch (e) {
+      expect(e).toBeInstanceOf(TRPCError)
+      expect((e as TRPCError).code).toBe('UNAUTHORIZED')
+    }
+  })
+})

--- a/apps/api/tests/identity/session-token.test.ts
+++ b/apps/api/tests/identity/session-token.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'bun:test'
+import { generateSessionToken, hashSessionToken } from '@brawltome/identity'
+
+describe('generateSessionToken', () => {
+  it('returns a url-safe base64 string of at least 40 chars', () => {
+    const token = generateSessionToken()
+    expect(token.length).toBeGreaterThanOrEqual(40)
+    expect(token).toMatch(/^[A-Za-z0-9_-]+$/)
+  })
+
+  it('does not collide across 1000 iterations', () => {
+    const tokens = new Set<string>()
+    for (let i = 0; i < 1000; i++) tokens.add(generateSessionToken())
+    expect(tokens.size).toBe(1000)
+  })
+})
+
+describe('hashSessionToken', () => {
+  it('returns a 64-char lowercase hex sha-256 digest', () => {
+    const hash = hashSessionToken('hello-world')
+    expect(hash).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  it('is deterministic', () => {
+    expect(hashSessionToken('abc')).toBe(hashSessionToken('abc'))
+  })
+
+  it('produces distinct digests for distinct inputs', () => {
+    expect(hashSessionToken('abc')).not.toBe(hashSessionToken('abd'))
+  })
+})

--- a/apps/api/tests/identity/sign-in-command.test.ts
+++ b/apps/api/tests/identity/sign-in-command.test.ts
@@ -86,10 +86,7 @@ describe('signInWithDiscord', () => {
     const sessionRepo = fakeSessionRepo()
     const before = Date.now()
 
-    await signInWithDiscord(
-      { userRepo, sessionRepo },
-      { discordId: '12345', username: 'x', avatarHash: null },
-    )
+    await signInWithDiscord({ userRepo, sessionRepo }, { discordId: '12345', username: 'x', avatarHash: null })
 
     const expiresAt = sessionRepo.rows[0].expiresAt.getTime()
     const thirtyDays = 30 * 24 * 60 * 60 * 1000

--- a/apps/api/tests/identity/sign-in-command.test.ts
+++ b/apps/api/tests/identity/sign-in-command.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'bun:test'
+import { signInWithDiscord } from '@brawltome/identity'
+import type { SessionRepo, UserRepo } from '@brawltome/identity'
+import type { Session, UserWithPrimaryAccount } from '@brawltome/identity'
+
+function fakeUserRepo(): UserRepo & { calls: { upsert: unknown[] } } {
+  const calls = { upsert: [] as unknown[] }
+  return {
+    calls,
+    async findByDiscordId() {
+      return null
+    },
+    async findById() {
+      return null
+    },
+    async upsertDiscordUser(profile) {
+      calls.upsert.push(profile)
+      const now = new Date()
+      return {
+        id: 'user-1',
+        createdAt: now,
+        updatedAt: now,
+        primaryAccount: {
+          userId: 'user-1',
+          provider: 'discord',
+          providerAccountId: profile.discordId,
+          username: profile.username,
+          avatarHash: profile.avatarHash,
+          refreshToken: null,
+          createdAt: now,
+          updatedAt: now,
+        },
+      } satisfies UserWithPrimaryAccount
+    },
+  }
+}
+
+function fakeSessionRepo(): SessionRepo & { rows: Session[] } {
+  const rows: Session[] = []
+  return {
+    rows,
+    async create({ id, userId, expiresAt }) {
+      const row: Session = { id, userId, expiresAt, createdAt: new Date() }
+      rows.push(row)
+      return row
+    },
+    async findById(id) {
+      return rows.find((r) => r.id === id) ?? null
+    },
+    async deleteById(id) {
+      const i = rows.findIndex((r) => r.id === id)
+      if (i >= 0) rows.splice(i, 1)
+    },
+    async extend(id, expiresAt) {
+      const row = rows.find((r) => r.id === id)
+      if (row) row.expiresAt = expiresAt
+    },
+    async deleteExpired() {
+      return 0
+    },
+  }
+}
+
+describe('signInWithDiscord', () => {
+  it('upserts the user, creates a session, and returns the raw token', async () => {
+    const userRepo = fakeUserRepo()
+    const sessionRepo = fakeSessionRepo()
+
+    const result = await signInWithDiscord(
+      { userRepo, sessionRepo },
+      { discordId: '12345', username: 'coolguy', avatarHash: 'abc' },
+    )
+
+    expect(userRepo.calls.upsert).toHaveLength(1)
+    expect(result.user.id).toBe('user-1')
+    expect(result.user.primaryAccount.username).toBe('coolguy')
+    expect(result.rawToken).toMatch(/^[A-Za-z0-9_-]+$/)
+    expect(sessionRepo.rows).toHaveLength(1)
+    // Session row must store the HASH, not the raw token
+    expect(sessionRepo.rows[0].id).not.toBe(result.rawToken)
+    expect(sessionRepo.rows[0].id).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  it('sets expiresAt ~30 days from now', async () => {
+    const userRepo = fakeUserRepo()
+    const sessionRepo = fakeSessionRepo()
+    const before = Date.now()
+
+    await signInWithDiscord(
+      { userRepo, sessionRepo },
+      { discordId: '12345', username: 'x', avatarHash: null },
+    )
+
+    const expiresAt = sessionRepo.rows[0].expiresAt.getTime()
+    const thirtyDays = 30 * 24 * 60 * 60 * 1000
+    expect(expiresAt - before).toBeGreaterThanOrEqual(thirtyDays - 1000)
+    expect(expiresAt - before).toBeLessThanOrEqual(thirtyDays + 1000)
+  })
+})

--- a/apps/desktop/core/src/api_client.rs
+++ b/apps/desktop/core/src/api_client.rs
@@ -32,7 +32,7 @@ impl ApiClient {
         let base_url = if base_url.is_empty() {
             DEFAULT_API_BASE.to_string()
         } else {
-            base_url
+            base_url.trim_end_matches('/').to_string()
         };
         Self {
             client: reqwest::Client::builder()

--- a/apps/desktop/core/src/main.rs
+++ b/apps/desktop/core/src/main.rs
@@ -208,6 +208,7 @@ fn main() {
             {
                 let handle = app.handle().clone();
                 let api_url = std::env::var("BRAWLTOME_API_URL")
+                    .map(|s| s.trim().to_string())
                     .unwrap_or_else(|_| "https://brawltome.app".into());
                 tauri::async_runtime::spawn(async move {
                     game_detection::run(handle, api_url).await;

--- a/apps/desktop/ui/components/OverlayPanel.tsx
+++ b/apps/desktop/ui/components/OverlayPanel.tsx
@@ -31,7 +31,7 @@ function SkeletonCard() {
 }
 
 export function OverlayPanel({ opponents, matchType, visible, scanning, refreshing }: OverlayPanelProps) {
-  const panelRef = useContentBounds<HTMLDivElement>()
+  const panelRef = useContentBounds<HTMLDivElement>(visible)
   const { onMouseLeave } = useCursorForwarding()
 
   if (!visible) return null

--- a/apps/desktop/ui/hooks/useContentBounds.ts
+++ b/apps/desktop/ui/hooks/useContentBounds.ts
@@ -1,12 +1,15 @@
 import { invoke } from '@tauri-apps/api/core'
 import { useEffect, useRef } from 'react'
 
-export function useContentBounds<T extends HTMLElement>() {
+export function useContentBounds<T extends HTMLElement>(active: boolean) {
   const ref = useRef<T>(null)
 
   useEffect(() => {
     const el = ref.current
-    if (!el) return
+    if (!el || !active) {
+      invoke('update_content_bounds', { x: 0, y: 0, width: 0, height: 0 })
+      return
+    }
 
     let lastX = 0
     let lastY = 0
@@ -15,7 +18,6 @@ export function useContentBounds<T extends HTMLElement>() {
 
     const report = () => {
       const rect = el.getBoundingClientRect()
-      // Only invoke if bounds actually changed
       if (rect.x === lastX && rect.y === lastY && rect.width === lastW && rect.height === lastH) {
         return
       }
@@ -31,19 +33,16 @@ export function useContentBounds<T extends HTMLElement>() {
       })
     }
 
-    // Report initially and on resize
     report()
     const observer = new ResizeObserver(report)
     observer.observe(el)
-
-    // Poll for position changes (ResizeObserver doesn't detect moves)
     const interval = setInterval(report, 500)
 
     return () => {
       observer.disconnect()
       clearInterval(interval)
     }
-  }, [])
+  }, [active])
 
   return ref
 }

--- a/apps/web/src/app/account/page.tsx
+++ b/apps/web/src/app/account/page.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import { useQueryClient } from '@tanstack/react-query'
-import Image from 'next/image'
+import { Link2, Monitor, Rss, Swords, Trophy, UserPlus, Users } from 'lucide-react'
 import { useSearchParams } from 'next/navigation'
-import { useMe, signIn, signOut } from '@/lib/auth'
+import { type Me, signIn, signOut, useMe } from '@/lib/auth'
+import { Skeleton } from '@brawltome/ui'
 
 const ERROR_MESSAGES: Record<string, string> = {
   state: 'Your sign-in attempt expired or was interrupted. Please try again.',
@@ -11,73 +12,203 @@ const ERROR_MESSAGES: Record<string, string> = {
   server: 'Something went wrong on our end. Please try again.',
 }
 
-export default function AccountPage() {
-  const { user, isLoading } = useMe()
-  const searchParams = useSearchParams()
-  const error = searchParams.get('error')
-  const queryClient = useQueryClient()
+const FEATURE_TEASERS = [
+  {
+    icon: UserPlus,
+    title: 'Follow Players',
+    description: 'Track your favorites and see live elo changes as they climb.',
+  },
+  {
+    icon: Monitor,
+    title: 'Desktop App',
+    description: 'Real-time overlay and match tracking. Requires an account.',
+  },
+  {
+    icon: Rss,
+    title: 'Activity Feed',
+    description: 'See when followed players rank up or hit new milestones.',
+  },
+  {
+    icon: Trophy,
+    title: 'Tournaments',
+    description: 'Compete in brackets and track results across seasons.',
+  },
+]
 
-  if (isLoading) {
-    return (
-      <main className="mx-auto flex min-h-[60vh] max-w-md items-center justify-center px-6">
-        <div className="text-muted-foreground text-sm">Loading...</div>
-      </main>
-    )
-  }
+function DiscordIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.947 2.418-2.157 2.418z" />
+    </svg>
+  )
+}
 
-  if (!user) {
-    return (
-      <main className="mx-auto flex min-h-[60vh] max-w-md flex-col items-center justify-center gap-6 px-6">
-        {error && ERROR_MESSAGES[error] && (
-          <div className="w-full rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-300">
-            {ERROR_MESSAGES[error]}
-          </div>
-        )}
-        <div className="text-center">
-          <h1 className="text-2xl font-bold tracking-tight">Sign in to BrawlTome</h1>
-          <p className="text-muted-foreground mt-2 text-sm">
-            Accounts are optional. Sign in to unlock follows, activity feed, and tournament features as they
-            ship.
-          </p>
+function LoadingState() {
+  return (
+    <main className="mx-auto flex min-h-[60vh] max-w-lg items-center justify-center px-6">
+      <div className="flex w-full flex-col items-center gap-6">
+        <Skeleton className="h-20 w-20 rounded-full" />
+        <Skeleton className="h-6 w-40" />
+        <Skeleton className="h-4 w-56" />
+      </div>
+    </main>
+  )
+}
+
+function SignedOutState({ error }: { error: string | null }) {
+  return (
+    <main className="mx-auto flex min-h-[60vh] max-w-2xl flex-col items-center justify-center px-6 py-12">
+      {error && ERROR_MESSAGES[error] && (
+        <div className="mb-8 w-full max-w-md rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-center text-sm text-red-300">
+          {ERROR_MESSAGES[error]}
         </div>
-        <button
-          type="button"
-          onClick={signIn}
-          className="inline-flex items-center justify-center rounded-xl bg-[#5865F2] px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-[#4752C4]"
-        >
-          Sign in with Discord
-        </button>
-      </main>
-    )
-  }
+      )}
+
+      <div className="text-center">
+        <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">Sign in to BrawlTome</h1>
+        <p className="text-muted-foreground mx-auto mt-3 max-w-sm text-base">
+          Create an account to unlock the full experience.
+        </p>
+      </div>
+
+      <button
+        type="button"
+        onClick={signIn}
+        className="mt-8 inline-flex cursor-pointer items-center gap-2.5 rounded-xl bg-[#5865F2] px-7 py-3.5 text-sm font-semibold text-white shadow-lg shadow-[#5865F2]/20 transition-all hover:bg-[#4752C4] hover:shadow-[#5865F2]/30 active:scale-[0.98]"
+      >
+        <DiscordIcon className="h-5 w-5" />
+        Continue with Discord
+      </button>
+
+      <div className="mt-14 grid w-full max-w-lg grid-cols-1 gap-3 sm:grid-cols-2">
+        {FEATURE_TEASERS.map((feature) => (
+          <div
+            key={feature.title}
+            className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-4 transition-colors hover:bg-white/[0.04]"
+          >
+            <div className="flex items-start gap-3">
+              <div className="mt-0.5 rounded-lg bg-white/[0.06] p-2">
+                <feature.icon className="text-muted-foreground h-4 w-4" />
+              </div>
+              <div className="min-w-0">
+                <p className="text-sm font-medium">{feature.title}</p>
+                <p className="text-muted-foreground mt-0.5 text-xs leading-relaxed">{feature.description}</p>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </main>
+  )
+}
+
+function SignedInState({ user }: { user: Me }) {
+  const queryClient = useQueryClient()
+  const memberSince = new Date(user.createdAt).toLocaleDateString('en-US', {
+    month: 'long',
+    year: 'numeric',
+  })
 
   return (
-    <main className="mx-auto flex min-h-[60vh] max-w-md flex-col items-center justify-center gap-6 px-6">
-      <div className="flex flex-col items-center gap-4">
-        {user.avatarUrl ? (
-          <Image
-            src={user.avatarUrl}
-            alt=""
-            width={96}
-            height={96}
-            className="h-24 w-24 rounded-full object-cover"
-            unoptimized
-          />
-        ) : (
-          <div className="bg-muted h-24 w-24 rounded-full" />
-        )}
-        <div className="text-center">
-          <h1 className="text-2xl font-bold tracking-tight">{user.username}</h1>
-          <p className="text-muted-foreground mt-1 text-xs">Signed in via Discord</p>
+    <main className="mx-auto flex min-h-[60vh] max-w-lg flex-col gap-6 px-6 py-12">
+      {/* Profile */}
+      <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-6">
+        <div className="flex items-center gap-4">
+          {user.avatarUrl ? (
+            // biome-ignore lint/performance/noImgElement: external avatar host
+            <img
+              src={user.avatarUrl}
+              alt=""
+              className="h-16 w-16 rounded-full object-cover ring-2 ring-white/[0.08]"
+            />
+          ) : (
+            <div className="bg-muted flex h-16 w-16 items-center justify-center rounded-full ring-2 ring-white/[0.08]">
+              <Users className="text-muted-foreground h-7 w-7" />
+            </div>
+          )}
+          <div className="min-w-0">
+            <h1 className="truncate text-xl font-bold tracking-tight">{user.username}</h1>
+            <div className="text-muted-foreground mt-1 flex items-center gap-2 text-xs">
+              <DiscordIcon className="h-3.5 w-3.5" />
+              <span>Connected via Discord</span>
+            </div>
+            <p className="text-muted-foreground mt-0.5 text-xs">Member since {memberSince}</p>
+          </div>
         </div>
       </div>
+
+      {/* Linked Accounts */}
+      <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-6">
+        <h2 className="text-sm font-semibold">Linked Accounts</h2>
+        <div className="mt-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <div className="rounded-lg bg-white/[0.06] p-2">
+                <Swords className="text-muted-foreground h-4 w-4" />
+              </div>
+              <div>
+                <p className="text-sm font-medium">Brawlhalla</p>
+                <p className="text-muted-foreground text-xs">Link your player profile</p>
+              </div>
+            </div>
+            <span className="text-muted-foreground rounded-full border border-white/[0.06] bg-white/[0.03] px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wider">
+              Soon
+            </span>
+          </div>
+          <div className="border-border/50 border-t" />
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <div className="rounded-lg bg-white/[0.06] p-2">
+                <Link2 className="text-muted-foreground h-4 w-4" />
+              </div>
+              <div>
+                <p className="text-sm font-medium">Socials</p>
+                <p className="text-muted-foreground text-xs">Connect your social profiles</p>
+              </div>
+            </div>
+            <span className="text-muted-foreground rounded-full border border-white/[0.06] bg-white/[0.03] px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wider">
+              Soon
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Following / Followers */}
+      <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-6">
+        <div className="flex items-center gap-4">
+          <div className="text-center">
+            <p className="text-lg font-bold">0</p>
+            <p className="text-muted-foreground text-xs">Following</p>
+          </div>
+          <div className="border-border/50 h-8 border-l" />
+          <div className="text-center">
+            <p className="text-lg font-bold">0</p>
+            <p className="text-muted-foreground text-xs">Followers</p>
+          </div>
+        </div>
+        <p className="text-muted-foreground mt-4 text-xs">
+          Follow players from their profile page to track their progress.
+        </p>
+      </div>
+
+      {/* Sign out */}
       <button
         type="button"
         onClick={() => signOut(queryClient)}
-        className="text-muted-foreground hover:text-foreground text-sm underline-offset-4 hover:underline"
+        className="text-muted-foreground hover:text-foreground cursor-pointer self-center text-sm underline-offset-4 transition-colors hover:underline"
       >
         Sign out
       </button>
     </main>
   )
+}
+
+export default function AccountPage() {
+  const { user, isLoading } = useMe()
+  const searchParams = useSearchParams()
+  const error = searchParams.get('error')
+
+  if (isLoading) return <LoadingState />
+  if (!user) return <SignedOutState error={error} />
+  return <SignedInState user={user} />
 }

--- a/apps/web/src/app/account/page.tsx
+++ b/apps/web/src/app/account/page.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useQueryClient } from '@tanstack/react-query'
-import { Link2, Monitor, Rss, Swords, Trophy, UserPlus, Users } from 'lucide-react'
+import { Gamepad2, Link2, Monitor, Rss, Trophy, UserPlus, Users } from 'lucide-react'
+import Image from 'next/image'
 import { useSearchParams } from 'next/navigation'
 import { type Me, signIn, signOut, useMe } from '@/lib/auth'
 import { Skeleton } from '@brawltome/ui'
@@ -57,47 +58,37 @@ function LoadingState() {
 
 function SignedOutState({ error }: { error: string | null }) {
   return (
-    <main className="mx-auto flex min-h-[60vh] max-w-2xl flex-col items-center justify-center px-6 py-12">
+    <main className="mx-auto flex max-w-md flex-col items-center pb-12">
       {error && ERROR_MESSAGES[error] && (
-        <div className="mb-8 w-full max-w-md rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-center text-sm text-red-300">
+        <div className="mb-8 w-full rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-center text-sm text-red-300">
           {ERROR_MESSAGES[error]}
         </div>
       )}
 
-      <div className="text-center">
-        <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">Sign in to BrawlTome</h1>
-        <p className="text-muted-foreground mx-auto mt-3 max-w-sm text-base">
-          Create an account to unlock the full experience.
-        </p>
+      <Image src="/images/logo.png" alt="BrawlTome" width={400} height={400} className="w-64" />
+
+      <h1 className="mt-6 text-2xl font-bold tracking-tight">Sign in</h1>
+
+      <div className="mt-10 w-full space-y-2">
+        {FEATURE_TEASERS.map((feature) => (
+          <div key={feature.title} className="flex items-center gap-3 rounded-lg px-3 py-2.5">
+            <feature.icon className="text-muted-foreground h-4 w-4 shrink-0" />
+            <div className="min-w-0">
+              <span className="text-sm font-medium">{feature.title}</span>
+              <span className="text-muted-foreground ml-2 text-xs">{feature.description}</span>
+            </div>
+          </div>
+        ))}
       </div>
 
       <button
         type="button"
         onClick={signIn}
-        className="mt-8 inline-flex cursor-pointer items-center gap-2.5 rounded-xl bg-[#5865F2] px-7 py-3.5 text-sm font-semibold text-white shadow-lg shadow-[#5865F2]/20 transition-all hover:bg-[#4752C4] hover:shadow-[#5865F2]/30 active:scale-[0.98]"
+        className="mt-8 inline-flex cursor-pointer items-center gap-2.5 rounded-xl bg-[#5865F2] px-7 py-3.5 text-sm font-semibold text-white transition-colors hover:bg-[#4752C4] active:scale-[0.98]"
       >
         <DiscordIcon className="h-5 w-5" />
         Continue with Discord
       </button>
-
-      <div className="mt-14 grid w-full max-w-lg grid-cols-1 gap-3 sm:grid-cols-2">
-        {FEATURE_TEASERS.map((feature) => (
-          <div
-            key={feature.title}
-            className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-4 transition-colors hover:bg-white/[0.04]"
-          >
-            <div className="flex items-start gap-3">
-              <div className="mt-0.5 rounded-lg bg-white/[0.06] p-2">
-                <feature.icon className="text-muted-foreground h-4 w-4" />
-              </div>
-              <div className="min-w-0">
-                <p className="text-sm font-medium">{feature.title}</p>
-                <p className="text-muted-foreground mt-0.5 text-xs leading-relaxed">{feature.description}</p>
-              </div>
-            </div>
-          </div>
-        ))}
-      </div>
     </main>
   )
 }
@@ -144,7 +135,7 @@ function SignedInState({ user }: { user: Me }) {
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
               <div className="rounded-lg bg-white/[0.06] p-2">
-                <Swords className="text-muted-foreground h-4 w-4" />
+                <Gamepad2 className="text-muted-foreground h-4 w-4" />
               </div>
               <div>
                 <p className="text-sm font-medium">Brawlhalla</p>

--- a/apps/web/src/app/account/page.tsx
+++ b/apps/web/src/app/account/page.tsx
@@ -1,11 +1,11 @@
 'use client'
 
+import { type Me, signIn, signOut, useMe } from '@/lib/auth'
+import { Skeleton } from '@brawltome/ui'
 import { useQueryClient } from '@tanstack/react-query'
 import { Gamepad2, Link2, Monitor, Rss, Trophy, UserPlus, Users } from 'lucide-react'
 import Image from 'next/image'
 import { useSearchParams } from 'next/navigation'
-import { type Me, signIn, signOut, useMe } from '@/lib/auth'
-import { Skeleton } from '@brawltome/ui'
 
 const ERROR_MESSAGES: Record<string, string> = {
   state: 'Your sign-in attempt expired or was interrupted. Please try again.',
@@ -106,12 +106,7 @@ function SignedInState({ user }: { user: Me }) {
       <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-6">
         <div className="flex items-center gap-4">
           {user.avatarUrl ? (
-            // biome-ignore lint/performance/noImgElement: external avatar host
-            <img
-              src={user.avatarUrl}
-              alt=""
-              className="h-16 w-16 rounded-full object-cover ring-2 ring-white/[0.08]"
-            />
+            <img src={user.avatarUrl} alt="" className="h-16 w-16 rounded-full object-cover ring-2 ring-white/[0.08]" />
           ) : (
             <div className="bg-muted flex h-16 w-16 items-center justify-center rounded-full ring-2 ring-white/[0.08]">
               <Users className="text-muted-foreground h-7 w-7" />

--- a/apps/web/src/app/account/page.tsx
+++ b/apps/web/src/app/account/page.tsx
@@ -1,11 +1,83 @@
-import type { Metadata } from 'next'
+'use client'
 
-import { WorkInProgress } from '@/components/WorkInProgress'
+import { useQueryClient } from '@tanstack/react-query'
+import Image from 'next/image'
+import { useSearchParams } from 'next/navigation'
+import { useMe, signIn, signOut } from '@/lib/auth'
 
-export const metadata: Metadata = {
-  title: 'Account - Coming Soon',
+const ERROR_MESSAGES: Record<string, string> = {
+  state: 'Your sign-in attempt expired or was interrupted. Please try again.',
+  discord: "We couldn't finish signing you in with Discord. Please try again in a moment.",
+  server: 'Something went wrong on our end. Please try again.',
 }
 
-export default function Page() {
-  return <WorkInProgress slug="account" />
+export default function AccountPage() {
+  const { user, isLoading } = useMe()
+  const searchParams = useSearchParams()
+  const error = searchParams.get('error')
+  const queryClient = useQueryClient()
+
+  if (isLoading) {
+    return (
+      <main className="mx-auto flex min-h-[60vh] max-w-md items-center justify-center px-6">
+        <div className="text-muted-foreground text-sm">Loading...</div>
+      </main>
+    )
+  }
+
+  if (!user) {
+    return (
+      <main className="mx-auto flex min-h-[60vh] max-w-md flex-col items-center justify-center gap-6 px-6">
+        {error && ERROR_MESSAGES[error] && (
+          <div className="w-full rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-300">
+            {ERROR_MESSAGES[error]}
+          </div>
+        )}
+        <div className="text-center">
+          <h1 className="text-2xl font-bold tracking-tight">Sign in to BrawlTome</h1>
+          <p className="text-muted-foreground mt-2 text-sm">
+            Accounts are optional. Sign in to unlock follows, activity feed, and tournament features as they
+            ship.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={signIn}
+          className="inline-flex items-center justify-center rounded-xl bg-[#5865F2] px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-[#4752C4]"
+        >
+          Sign in with Discord
+        </button>
+      </main>
+    )
+  }
+
+  return (
+    <main className="mx-auto flex min-h-[60vh] max-w-md flex-col items-center justify-center gap-6 px-6">
+      <div className="flex flex-col items-center gap-4">
+        {user.avatarUrl ? (
+          <Image
+            src={user.avatarUrl}
+            alt=""
+            width={96}
+            height={96}
+            className="h-24 w-24 rounded-full object-cover"
+            unoptimized
+          />
+        ) : (
+          <div className="bg-muted h-24 w-24 rounded-full" />
+        )}
+        <div className="text-center">
+          <h1 className="text-2xl font-bold tracking-tight">{user.username}</h1>
+          <p className="text-muted-foreground mt-1 text-xs">Signed in via Discord</p>
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={() => signOut(queryClient)}
+        className="text-muted-foreground hover:text-foreground text-sm underline-offset-4 hover:underline"
+      >
+        Sign out
+      </button>
+    </main>
+  )
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -50,15 +50,15 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" className="dark" suppressHydrationWarning>
       <body className="min-h-screen font-sans antialiased">
         <Providers>
-        <SidebarProvider>
-          <div className="bg-background text-foreground min-h-screen">
-            {isMaintenanceMode ? (
-              <MaintenancePage maintenanceEnd={maintenanceEnd} />
-            ) : (
-              <SidebarLayout>{children}</SidebarLayout>
-            )}
-          </div>
-        </SidebarProvider>
+          <SidebarProvider>
+            <div className="bg-background text-foreground min-h-screen">
+              {isMaintenanceMode ? (
+                <MaintenancePage maintenanceEnd={maintenanceEnd} />
+              ) : (
+                <SidebarLayout>{children}</SidebarLayout>
+              )}
+            </div>
+          </SidebarProvider>
         </Providers>
       </body>
     </html>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css'
 import { MaintenancePage } from '@/components/MaintenancePage'
+import { Providers } from '@/components/Providers'
 import { SidebarLayout } from '@/components/sidebar/SidebarLayout'
 import { SidebarProvider } from '@/components/sidebar/SidebarProvider'
 import type { Metadata } from 'next'
@@ -48,6 +49,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" className="dark" suppressHydrationWarning>
       <body className="min-h-screen font-sans antialiased">
+        <Providers>
         <SidebarProvider>
           <div className="bg-background text-foreground min-h-screen">
             {isMaintenanceMode ? (
@@ -57,6 +59,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             )}
           </div>
         </SidebarProvider>
+        </Providers>
       </body>
     </html>
   )

--- a/apps/web/src/components/Providers.tsx
+++ b/apps/web/src/components/Providers.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useState } from 'react'
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 60 * 1000,
+            refetchOnWindowFocus: false,
+          },
+        },
+      }),
+  )
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}

--- a/apps/web/src/components/sidebar/AppSidebar.tsx
+++ b/apps/web/src/components/sidebar/AppSidebar.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import type { ReactNode } from 'react'
 
+import { useMe } from '@/lib/auth'
 import { navItems } from './nav-items'
 import { socialLinks } from './social-links'
 
@@ -38,6 +39,7 @@ function WithTooltip({
  */
 export function AppSidebar() {
   const pathname = usePathname()
+  const { user } = useMe()
 
   return (
     <TooltipProvider>
@@ -99,15 +101,20 @@ export function AppSidebar() {
           </div>
 
           <div className="border-sidebar-border border-t pt-2 pb-1">
-            <WithTooltip label="Sign in">
+            <WithTooltip label={user ? user.username : 'Sign in'}>
               <Link
                 href="/account"
-                aria-label="Sign in"
+                aria-label={user ? 'Account' : 'Sign in'}
                 aria-current={pathname === '/account' ? 'page' : undefined}
                 className="group flex w-10 items-center rounded-lg"
               >
                 <div className="bg-sidebar-accent text-muted-foreground border-sidebar group-hover:brightness-150 flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-lg border-2 transition-all">
-                  <User className="h-6 w-6" weight="Linear" />
+                  {user?.avatarUrl ? (
+                    // biome-ignore lint/performance/noImgElement: external avatar host, no next/image remoteConfig yet
+                    <img src={user.avatarUrl} alt="" className="h-full w-full object-cover" />
+                  ) : (
+                    <User className="h-6 w-6" weight="Linear" />
+                  )}
                 </div>
               </Link>
             </WithTooltip>

--- a/apps/web/src/components/sidebar/AppSidebar.tsx
+++ b/apps/web/src/components/sidebar/AppSidebar.tsx
@@ -110,7 +110,6 @@ export function AppSidebar() {
               >
                 <div className="bg-sidebar-accent text-muted-foreground border-sidebar group-hover:brightness-150 flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-lg border-2 transition-all">
                   {user?.avatarUrl ? (
-                    // biome-ignore lint/performance/noImgElement: external avatar host, no next/image remoteConfig yet
                     <img src={user.avatarUrl} alt="" className="h-full w-full object-cover" />
                   ) : (
                     <User className="h-6 w-6" weight="Linear" />

--- a/apps/web/src/components/sidebar/MobileMenu.tsx
+++ b/apps/web/src/components/sidebar/MobileMenu.tsx
@@ -121,7 +121,6 @@ export function MobileMenu() {
             className="text-muted-foreground hover:bg-white/[0.04] hover:text-foreground inline-flex items-center gap-2.5 rounded-xl px-1.5 py-2.5 text-base font-medium transition-colors"
           >
             {user?.avatarUrl ? (
-              // biome-ignore lint/performance/noImgElement: external avatar host
               <img src={user.avatarUrl} alt="" className="h-6 w-6 rounded-full object-cover" />
             ) : (
               <User className="h-5 w-5" weight="Linear" />

--- a/apps/web/src/components/sidebar/MobileMenu.tsx
+++ b/apps/web/src/components/sidebar/MobileMenu.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useEffect, useLayoutEffect, useRef } from 'react'
 
+import { useMe } from '@/lib/auth'
 import { useSidebar } from './SidebarProvider'
 import { navItems } from './nav-items'
 import { socialLinks } from './social-links'
@@ -17,6 +18,7 @@ import { socialLinks } from './social-links'
 export function MobileMenu() {
   const { isMobileOpen, close } = useSidebar()
   const pathname = usePathname()
+  const { user } = useMe()
   const dialogRef = useRef<HTMLDialogElement>(null)
 
   // Body scroll lock while open. iOS Safari still scrolls the document behind
@@ -118,8 +120,13 @@ export function MobileMenu() {
             href="/account"
             className="text-muted-foreground hover:bg-white/[0.04] hover:text-foreground inline-flex items-center gap-2.5 rounded-xl px-1.5 py-2.5 text-base font-medium transition-colors"
           >
-            <User className="h-5 w-5" weight="Linear" />
-            Sign in
+            {user?.avatarUrl ? (
+              // biome-ignore lint/performance/noImgElement: external avatar host
+              <img src={user.avatarUrl} alt="" className="h-6 w-6 rounded-full object-cover" />
+            ) : (
+              <User className="h-5 w-5" weight="Linear" />
+            )}
+            {user ? user.username : 'Sign in'}
           </Link>
 
           <div className="flex items-center gap-1">

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useQuery, type useQueryClient } from '@tanstack/react-query'
 import { trpc } from './trpc'
 
 const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3000'

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,0 +1,34 @@
+'use client'
+
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { trpc } from './trpc'
+
+const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3000'
+
+export interface Me {
+  id: string
+  username: string
+  avatarUrl: string | null
+}
+
+const ME_KEY = ['identity', 'me'] as const
+
+export function useMe() {
+  const query = useQuery({
+    queryKey: ME_KEY,
+    queryFn: async (): Promise<Me | null> => {
+      return (await trpc.identity.me.query()) as Me | null
+    },
+    staleTime: 5 * 60 * 1000,
+  })
+  return { user: query.data ?? null, isLoading: query.isLoading }
+}
+
+export function signIn(): void {
+  window.location.href = `${apiUrl}/auth/discord/login`
+}
+
+export async function signOut(queryClient: ReturnType<typeof useQueryClient>): Promise<void> {
+  await fetch(`${apiUrl}/auth/signout`, { method: 'POST', credentials: 'include' })
+  await queryClient.invalidateQueries({ queryKey: ME_KEY })
+}

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -9,6 +9,7 @@ export interface Me {
   id: string
   username: string
   avatarUrl: string | null
+  createdAt: string
 }
 
 const ME_KEY = ['identity', 'me'] as const

--- a/apps/web/src/lib/trpc.ts
+++ b/apps/web/src/lib/trpc.ts
@@ -9,6 +9,7 @@ export const trpc = createTRPCClient<AppRouter>({
     httpBatchLink({
       url: `${apiUrl}/trpc`,
       transformer: superjson,
+      fetch: (url, opts) => fetch(url, { ...opts, credentials: 'include' }),
     }),
   ],
 })

--- a/apps/web/src/lib/wip-features.ts
+++ b/apps/web/src/lib/wip-features.ts
@@ -1,4 +1,4 @@
-import { BookBookmark, Cup, Gamepad, type IconProps, PieChart, User, UsersGroupRounded } from '@solar-icons/react'
+import { BookBookmark, Cup, Gamepad, type IconProps, PieChart, UsersGroupRounded } from '@solar-icons/react'
 import type { ComponentType } from 'react'
 
 export interface WipFeature {
@@ -21,12 +21,6 @@ export const wipFeatures = {
     description:
       'Legends and weapons ranked by win rate, pick rate, tier. Filter by rank bracket and region. Pulled from every ranked player we track, updated as the meta shifts',
     icon: PieChart,
-  },
-  account: {
-    title: 'Account',
-    tagline: 'Your BrawlTome profile. One-click lookups, bookmarks',
-    description: "Sign in. Save your Brawlhalla ID for instant lookups. Bookmark the players and clans you're tracking",
-    icon: User,
   },
   matches: {
     title: 'Matches',

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "@brawltome/bhapi": "workspace:*",
         "@brawltome/clan": "workspace:*",
         "@brawltome/database": "workspace:*",
+        "@brawltome/identity": "workspace:*",
         "@brawltome/player": "workspace:*",
         "@brawltome/ranking": "workspace:*",
         "@brawltome/shared": "workspace:*",

--- a/packages/contexts/identity/commands/sign-in-with-discord.ts
+++ b/packages/contexts/identity/commands/sign-in-with-discord.ts
@@ -1,0 +1,36 @@
+import { SESSION_TTL_MS, generateSessionToken, hashSessionToken } from '../session'
+import type { SessionRepo } from '../session.repo'
+import type { UserWithPrimaryAccount } from '../user'
+import type { UserRepo } from '../user.repo'
+
+export interface SignInWithDiscordDeps {
+  userRepo: UserRepo
+  sessionRepo: SessionRepo
+}
+
+export interface DiscordProfile {
+  discordId: string
+  username: string
+  avatarHash: string | null
+}
+
+export interface SignInResult {
+  user: UserWithPrimaryAccount
+  rawToken: string
+  expiresAt: Date
+}
+
+export async function signInWithDiscord(
+  deps: SignInWithDiscordDeps,
+  profile: DiscordProfile,
+): Promise<SignInResult> {
+  const user = await deps.userRepo.upsertDiscordUser(profile)
+
+  const rawToken = generateSessionToken()
+  const hashed = hashSessionToken(rawToken)
+  const expiresAt = new Date(Date.now() + SESSION_TTL_MS)
+
+  await deps.sessionRepo.create({ id: hashed, userId: user.id, expiresAt })
+
+  return { user, rawToken, expiresAt }
+}

--- a/packages/contexts/identity/commands/sign-in-with-discord.ts
+++ b/packages/contexts/identity/commands/sign-in-with-discord.ts
@@ -20,10 +20,7 @@ export interface SignInResult {
   expiresAt: Date
 }
 
-export async function signInWithDiscord(
-  deps: SignInWithDiscordDeps,
-  profile: DiscordProfile,
-): Promise<SignInResult> {
+export async function signInWithDiscord(deps: SignInWithDiscordDeps, profile: DiscordProfile): Promise<SignInResult> {
   const user = await deps.userRepo.upsertDiscordUser(profile)
 
   const rawToken = generateSessionToken()

--- a/packages/contexts/identity/commands/sign-out.ts
+++ b/packages/contexts/identity/commands/sign-out.ts
@@ -1,0 +1,10 @@
+import { hashSessionToken } from '../session'
+import type { SessionRepo } from '../session.repo'
+
+export interface SignOutDeps {
+  sessionRepo: SessionRepo
+}
+
+export async function signOut(deps: SignOutDeps, rawToken: string): Promise<void> {
+  await deps.sessionRepo.deleteById(hashSessionToken(rawToken))
+}

--- a/packages/contexts/identity/index.ts
+++ b/packages/contexts/identity/index.ts
@@ -1,3 +1,8 @@
 export type { User, OAuthAccount, UserWithPrimaryAccount } from './user'
 export type { Session } from './session'
-export { SESSION_TTL_MS, SESSION_EXTEND_THRESHOLD_MS } from './session'
+export {
+  SESSION_TTL_MS,
+  SESSION_EXTEND_THRESHOLD_MS,
+  generateSessionToken,
+  hashSessionToken,
+} from './session'

--- a/packages/contexts/identity/index.ts
+++ b/packages/contexts/identity/index.ts
@@ -6,3 +6,4 @@ export {
   generateSessionToken,
   hashSessionToken,
 } from './session'
+export { createUserRepo, type UserRepo } from './user.repo'

--- a/packages/contexts/identity/index.ts
+++ b/packages/contexts/identity/index.ts
@@ -7,3 +7,4 @@ export {
   hashSessionToken,
 } from './session'
 export { createUserRepo, type UserRepo } from './user.repo'
+export { createSessionRepo, type SessionRepo } from './session.repo'

--- a/packages/contexts/identity/index.ts
+++ b/packages/contexts/identity/index.ts
@@ -8,3 +8,9 @@ export {
 } from './session'
 export { createUserRepo, type UserRepo } from './user.repo'
 export { createSessionRepo, type SessionRepo } from './session.repo'
+export { signInWithDiscord } from './commands/sign-in-with-discord'
+export type {
+  SignInWithDiscordDeps,
+  DiscordProfile,
+  SignInResult,
+} from './commands/sign-in-with-discord'

--- a/packages/contexts/identity/index.ts
+++ b/packages/contexts/identity/index.ts
@@ -1,0 +1,3 @@
+export type { User, OAuthAccount, UserWithPrimaryAccount } from './user'
+export type { Session } from './session'
+export { SESSION_TTL_MS, SESSION_EXTEND_THRESHOLD_MS } from './session'

--- a/packages/contexts/identity/index.ts
+++ b/packages/contexts/identity/index.ts
@@ -14,3 +14,7 @@ export type {
   DiscordProfile,
   SignInResult,
 } from './commands/sign-in-with-discord'
+export { signOut } from './commands/sign-out'
+export type { SignOutDeps } from './commands/sign-out'
+export { getCurrentUser } from './queries/get-current-user'
+export type { GetCurrentUserDeps, CurrentUserResult } from './queries/get-current-user'

--- a/packages/contexts/identity/queries/get-current-user.ts
+++ b/packages/contexts/identity/queries/get-current-user.ts
@@ -1,0 +1,43 @@
+import { SESSION_EXTEND_THRESHOLD_MS, SESSION_TTL_MS, hashSessionToken } from '../session'
+import type { Session } from '../session'
+import type { SessionRepo } from '../session.repo'
+import type { UserWithPrimaryAccount } from '../user'
+import type { UserRepo } from '../user.repo'
+
+export interface GetCurrentUserDeps {
+  userRepo: UserRepo
+  sessionRepo: SessionRepo
+}
+
+export interface CurrentUserResult {
+  user: UserWithPrimaryAccount
+  session: Session
+  extended: boolean
+}
+
+export async function getCurrentUser(
+  deps: GetCurrentUserDeps,
+  rawToken: string | null,
+): Promise<CurrentUserResult | null> {
+  if (!rawToken) return null
+
+  const id = hashSessionToken(rawToken)
+  const session = await deps.sessionRepo.findById(id)
+  if (!session) return null
+
+  const now = Date.now()
+  if (session.expiresAt.getTime() <= now) return null
+
+  const user = await deps.userRepo.findById(session.userId)
+  if (!user) return null
+
+  let extended = false
+  if (session.expiresAt.getTime() - now < SESSION_EXTEND_THRESHOLD_MS) {
+    const newExpiry = new Date(now + SESSION_TTL_MS)
+    await deps.sessionRepo.extend(id, newExpiry)
+    session.expiresAt = newExpiry
+    extended = true
+  }
+
+  return { user, session, extended }
+}

--- a/packages/contexts/identity/session.repo.ts
+++ b/packages/contexts/identity/session.repo.ts
@@ -1,0 +1,39 @@
+import type { Database } from '@brawltome/database'
+import { session } from '@brawltome/database'
+import { eq, lt } from 'drizzle-orm'
+import type { Session } from './session'
+
+export interface SessionRepo {
+  create(params: { id: string; userId: string; expiresAt: Date }): Promise<Session>
+  findById(id: string): Promise<Session | null>
+  deleteById(id: string): Promise<void>
+  extend(id: string, expiresAt: Date): Promise<void>
+  deleteExpired(now: Date): Promise<number>
+}
+
+export function createSessionRepo(db: Database): SessionRepo {
+  return {
+    async create({ id, userId, expiresAt }) {
+      const [row] = await db.insert(session).values({ id, userId, expiresAt }).returning()
+      return row
+    },
+
+    async findById(id) {
+      const row = await db.query.session.findFirst({ where: eq(session.id, id) })
+      return row ?? null
+    },
+
+    async deleteById(id) {
+      await db.delete(session).where(eq(session.id, id))
+    },
+
+    async extend(id, expiresAt) {
+      await db.update(session).set({ expiresAt }).where(eq(session.id, id))
+    },
+
+    async deleteExpired(now) {
+      const rows = await db.delete(session).where(lt(session.expiresAt, now)).returning({ id: session.id })
+      return rows.length
+    },
+  }
+}

--- a/packages/contexts/identity/session.ts
+++ b/packages/contexts/identity/session.ts
@@ -1,3 +1,5 @@
+import { createHash, randomBytes } from 'node:crypto'
+
 export interface Session {
   id: string
   userId: string
@@ -7,3 +9,11 @@ export interface Session {
 
 export const SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000 // 30 days
 export const SESSION_EXTEND_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
+
+export function generateSessionToken(): string {
+  return randomBytes(32).toString('base64url')
+}
+
+export function hashSessionToken(rawToken: string): string {
+  return createHash('sha256').update(rawToken).digest('hex')
+}

--- a/packages/contexts/identity/session.ts
+++ b/packages/contexts/identity/session.ts
@@ -1,0 +1,9 @@
+export interface Session {
+  id: string
+  userId: string
+  expiresAt: Date
+  createdAt: Date
+}
+
+export const SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000 // 30 days
+export const SESSION_EXTEND_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000 // 7 days

--- a/packages/contexts/identity/user.repo.ts
+++ b/packages/contexts/identity/user.repo.ts
@@ -38,10 +38,7 @@ export function createUserRepo(db: Database): UserRepo {
     async upsertDiscordUser(profile) {
       return db.transaction(async (tx) => {
         const existing = await tx.query.oauthAccount.findFirst({
-          where: and(
-            eq(oauthAccount.provider, 'discord'),
-            eq(oauthAccount.providerAccountId, profile.discordId),
-          ),
+          where: and(eq(oauthAccount.provider, 'discord'), eq(oauthAccount.providerAccountId, profile.discordId)),
           with: { user: true },
         })
 
@@ -53,12 +50,7 @@ export function createUserRepo(db: Database): UserRepo {
               avatarHash: profile.avatarHash,
               updatedAt: new Date(),
             })
-            .where(
-              and(
-                eq(oauthAccount.provider, 'discord'),
-                eq(oauthAccount.providerAccountId, profile.discordId),
-              ),
-            )
+            .where(and(eq(oauthAccount.provider, 'discord'), eq(oauthAccount.providerAccountId, profile.discordId)))
             .returning()
           return attachPrimary(existing.user, updated)
         }
@@ -99,7 +91,7 @@ function attachPrimary(
     updatedAt: u.updatedAt,
     primaryAccount: {
       userId: a.userId,
-      provider: 'discord',
+      provider: a.provider as 'discord',
       providerAccountId: a.providerAccountId,
       username: a.username,
       avatarHash: a.avatarHash,

--- a/packages/contexts/identity/user.repo.ts
+++ b/packages/contexts/identity/user.repo.ts
@@ -1,0 +1,111 @@
+import type { Database } from '@brawltome/database'
+import { oauthAccount, user } from '@brawltome/database'
+import { and, eq } from 'drizzle-orm'
+import type { OAuthAccount, User, UserWithPrimaryAccount } from './user'
+
+export interface UserRepo {
+  findByDiscordId(discordId: string): Promise<UserWithPrimaryAccount | null>
+  findById(userId: string): Promise<UserWithPrimaryAccount | null>
+  upsertDiscordUser(profile: {
+    discordId: string
+    username: string
+    avatarHash: string | null
+  }): Promise<UserWithPrimaryAccount>
+}
+
+export function createUserRepo(db: Database): UserRepo {
+  return {
+    async findByDiscordId(discordId) {
+      const row = await db.query.oauthAccount.findFirst({
+        where: and(eq(oauthAccount.provider, 'discord'), eq(oauthAccount.providerAccountId, discordId)),
+        with: { user: true },
+      })
+      if (!row) return null
+      return attachPrimary(row.user, row)
+    },
+
+    async findById(userId) {
+      const u = await db.query.user.findFirst({
+        where: eq(user.id, userId),
+        with: { oauthAccounts: true },
+      })
+      if (!u) return null
+      const primary = u.oauthAccounts.find((a) => a.provider === 'discord') ?? u.oauthAccounts[0]
+      if (!primary) return null
+      return attachPrimary(u, primary)
+    },
+
+    async upsertDiscordUser(profile) {
+      return db.transaction(async (tx) => {
+        const existing = await tx.query.oauthAccount.findFirst({
+          where: and(
+            eq(oauthAccount.provider, 'discord'),
+            eq(oauthAccount.providerAccountId, profile.discordId),
+          ),
+          with: { user: true },
+        })
+
+        if (existing) {
+          const [updated] = await tx
+            .update(oauthAccount)
+            .set({
+              username: profile.username,
+              avatarHash: profile.avatarHash,
+              updatedAt: new Date(),
+            })
+            .where(
+              and(
+                eq(oauthAccount.provider, 'discord'),
+                eq(oauthAccount.providerAccountId, profile.discordId),
+              ),
+            )
+            .returning()
+          return attachPrimary(existing.user, updated)
+        }
+
+        const [newUser] = await tx.insert(user).values({}).returning()
+        const [newAccount] = await tx
+          .insert(oauthAccount)
+          .values({
+            userId: newUser.id,
+            provider: 'discord',
+            providerAccountId: profile.discordId,
+            username: profile.username,
+            avatarHash: profile.avatarHash,
+          })
+          .returning()
+        return attachPrimary(newUser, newAccount)
+      })
+    },
+  }
+}
+
+function attachPrimary(
+  u: { id: string; createdAt: Date; updatedAt: Date },
+  a: {
+    userId: string
+    provider: string
+    providerAccountId: string
+    username: string
+    avatarHash: string | null
+    refreshToken: string | null
+    createdAt: Date
+    updatedAt: Date
+  },
+): UserWithPrimaryAccount {
+  return {
+    id: u.id,
+    createdAt: u.createdAt,
+    updatedAt: u.updatedAt,
+    primaryAccount: {
+      userId: a.userId,
+      provider: 'discord',
+      providerAccountId: a.providerAccountId,
+      username: a.username,
+      avatarHash: a.avatarHash,
+      refreshToken: a.refreshToken,
+      createdAt: a.createdAt,
+      updatedAt: a.updatedAt,
+    },
+  }
+}

--- a/packages/contexts/identity/user.ts
+++ b/packages/contexts/identity/user.ts
@@ -1,0 +1,20 @@
+export interface User {
+  id: string
+  createdAt: Date
+  updatedAt: Date
+}
+
+export interface OAuthAccount {
+  userId: string
+  provider: 'discord'
+  providerAccountId: string
+  username: string
+  avatarHash: string | null
+  refreshToken: string | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+export interface UserWithPrimaryAccount extends User {
+  primaryAccount: OAuthAccount
+}

--- a/packages/database/drizzle/0005_supreme_cargill.sql
+++ b/packages/database/drizzle/0005_supreme_cargill.sql
@@ -1,0 +1,32 @@
+CREATE TABLE "oauth_account" (
+	"provider" varchar(32) NOT NULL,
+	"provider_account_id" varchar(64) NOT NULL,
+	"user_id" uuid NOT NULL,
+	"username" varchar(64) NOT NULL,
+	"avatar_hash" varchar(128),
+	"refresh_token" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "oauth_account_provider_provider_account_id_pk" PRIMARY KEY("provider","provider_account_id")
+);
+--> statement-breakpoint
+CREATE TABLE "session" (
+	"id" varchar(64) PRIMARY KEY NOT NULL,
+	"user_id" uuid NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "user" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "discord_link" DISABLE ROW LEVEL SECURITY;--> statement-breakpoint
+DROP TABLE "discord_link" CASCADE;--> statement-breakpoint
+ALTER TABLE "legend" ALTER COLUMN "bio_quote_from_attrib" SET DATA TYPE text;--> statement-breakpoint
+ALTER TABLE "oauth_account" ADD CONSTRAINT "oauth_account_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "session" ADD CONSTRAINT "session_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_oauth_account_user_provider" ON "oauth_account" USING btree ("user_id","provider");--> statement-breakpoint
+CREATE INDEX "idx_session_user_id" ON "session" USING btree ("user_id");

--- a/packages/database/drizzle/meta/0005_snapshot.json
+++ b/packages/database/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,1669 @@
+{
+  "id": "9b324f87-5f76-41cf-a7a7-f27283dd8096",
+  "prevId": "da617a58-254f-47ef-aa37-a1ab005f81e0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.blacklist": {
+      "name": "blacklist",
+      "schema": "",
+      "columns": {
+        "brawlhalla_id": {
+          "name": "brawlhalla_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clan": {
+      "name": "clan",
+      "schema": "",
+      "columns": {
+        "clan_id": {
+          "name": "clan_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clan_name": {
+          "name": "clan_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clan_create_date": {
+          "name": "clan_create_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clan_xp": {
+          "name": "clan_xp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clan_lifetime_xp": {
+          "name": "clan_lifetime_xp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clan_member": {
+      "name": "clan_member",
+      "schema": "",
+      "columns": {
+        "clan_id": {
+          "name": "clan_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brawlhalla_id": {
+          "name": "brawlhalla_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "join_date": {
+          "name": "join_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xp": {
+          "name": "xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legend_name_key": {
+          "name": "legend_name_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "clan_member_clan_id_clan_clan_id_fk": {
+          "name": "clan_member_clan_id_clan_clan_id_fk",
+          "tableFrom": "clan_member",
+          "tableTo": "clan",
+          "columnsFrom": [
+            "clan_id"
+          ],
+          "columnsTo": [
+            "clan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "clan_member_clan_id_brawlhalla_id_pk": {
+          "name": "clan_member_clan_id_brawlhalla_id_pk",
+          "columns": [
+            "clan_id",
+            "brawlhalla_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legend": {
+      "name": "legend",
+      "schema": "",
+      "columns": {
+        "legend_id": {
+          "name": "legend_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "legend_name_key": {
+          "name": "legend_name_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio_name": {
+          "name": "bio_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio_aka": {
+          "name": "bio_aka",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio_quote": {
+          "name": "bio_quote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio_quote_about_attrib": {
+          "name": "bio_quote_about_attrib",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio_quote_from": {
+          "name": "bio_quote_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio_quote_from_attrib": {
+          "name": "bio_quote_from_attrib",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio_text": {
+          "name": "bio_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_name": {
+          "name": "bot_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weapon_one": {
+          "name": "weapon_one",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weapon_two": {
+          "name": "weapon_two",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strength": {
+          "name": "strength",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dexterity": {
+          "name": "dexterity",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defense": {
+          "name": "defense",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "speed": {
+          "name": "speed",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_legend_name_key": {
+          "name": "idx_legend_name_key",
+          "columns": [
+            {
+              "expression": "legend_name_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_account": {
+      "name": "oauth_account",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_hash": {
+          "name": "avatar_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_oauth_account_user_provider": {
+          "name": "uq_oauth_account_user_provider",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_account_user_id_user_id_fk": {
+          "name": "oauth_account_user_id_user_id_fk",
+          "tableFrom": "oauth_account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "oauth_account_provider_provider_account_id_pk": {
+          "name": "oauth_account_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player": {
+      "name": "player",
+      "schema": "",
+      "columns": {
+        "brawlhalla_id": {
+          "name": "brawlhalla_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "peak_rating": {
+          "name": "peak_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "tier": {
+          "name": "tier",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ranked_games": {
+          "name": "ranked_games",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ranked_wins": {
+          "name": "ranked_wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ranked_last_updated": {
+          "name": "ranked_last_updated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "best_legend": {
+          "name": "best_legend",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "best_legend_games": {
+          "name": "best_legend_games",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "best_legend_wins": {
+          "name": "best_legend_wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "xp": {
+          "name": "xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xp_percentage": {
+          "name": "xp_percentage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_games": {
+          "name": "total_games",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_wins": {
+          "name": "total_wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_time_total": {
+          "name": "match_time_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "damage_bomb": {
+          "name": "damage_bomb",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "damage_mine": {
+          "name": "damage_mine",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "damage_spikeball": {
+          "name": "damage_spikeball",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "damage_sidekick": {
+          "name": "damage_sidekick",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hit_snowball": {
+          "name": "hit_snowball",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ko_bomb": {
+          "name": "ko_bomb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ko_mine": {
+          "name": "ko_mine",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ko_spikeball": {
+          "name": "ko_spikeball",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ko_sidekick": {
+          "name": "ko_sidekick",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ko_snowball": {
+          "name": "ko_snowball",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats_last_updated": {
+          "name": "stats_last_updated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valhallan_confirmed_at": {
+          "name": "valhallan_confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "refresh_tier": {
+          "name": "refresh_tier",
+          "type": "refresh_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cold'"
+        }
+      },
+      "indexes": {
+        "idx_player_name": {
+          "name": "idx_player_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_player_view_count": {
+          "name": "idx_player_view_count",
+          "columns": [
+            {
+              "expression": "view_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_player_rating": {
+          "name": "idx_player_rating",
+          "columns": [
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_player_peak_rating": {
+          "name": "idx_player_peak_rating",
+          "columns": [
+            {
+              "expression": "peak_rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_player_wins": {
+          "name": "idx_player_wins",
+          "columns": [
+            {
+              "expression": "ranked_wins",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_player_games": {
+          "name": "idx_player_games",
+          "columns": [
+            {
+              "expression": "ranked_games",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_player_region_rating": {
+          "name": "idx_player_region_rating",
+          "columns": [
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_player_region_peak_rating": {
+          "name": "idx_player_region_peak_rating",
+          "columns": [
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "peak_rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_player_region_wins": {
+          "name": "idx_player_region_wins",
+          "columns": [
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ranked_wins",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_player_region_games": {
+          "name": "idx_player_region_games",
+          "columns": [
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ranked_games",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_alias": {
+      "name": "player_alias",
+      "schema": "",
+      "columns": {
+        "brawlhalla_id": {
+          "name": "brawlhalla_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_alias_key": {
+          "name": "idx_alias_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "player_alias_brawlhalla_id_player_brawlhalla_id_fk": {
+          "name": "player_alias_brawlhalla_id_player_brawlhalla_id_fk",
+          "tableFrom": "player_alias",
+          "tableTo": "player",
+          "columnsFrom": [
+            "brawlhalla_id"
+          ],
+          "columnsTo": [
+            "brawlhalla_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "player_alias_brawlhalla_id_key_pk": {
+          "name": "player_alias_brawlhalla_id_key_pk",
+          "columns": [
+            "brawlhalla_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_clan": {
+      "name": "player_clan",
+      "schema": "",
+      "columns": {
+        "brawlhalla_id": {
+          "name": "brawlhalla_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clan_name": {
+          "name": "clan_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clan_id": {
+          "name": "clan_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clan_xp": {
+          "name": "clan_xp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clan_lifetime_xp": {
+          "name": "clan_lifetime_xp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "personal_xp": {
+          "name": "personal_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "player_clan_brawlhalla_id_player_brawlhalla_id_fk": {
+          "name": "player_clan_brawlhalla_id_player_brawlhalla_id_fk",
+          "tableFrom": "player_clan",
+          "tableTo": "player",
+          "columnsFrom": [
+            "brawlhalla_id"
+          ],
+          "columnsTo": [
+            "brawlhalla_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_ranked_legend": {
+      "name": "player_ranked_legend",
+      "schema": "",
+      "columns": {
+        "brawlhalla_id": {
+          "name": "brawlhalla_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legend_id": {
+          "name": "legend_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legend_name_key": {
+          "name": "legend_name_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rating": {
+          "name": "peak_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wins": {
+          "name": "wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "games": {
+          "name": "games",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "player_ranked_legend_brawlhalla_id_player_brawlhalla_id_fk": {
+          "name": "player_ranked_legend_brawlhalla_id_player_brawlhalla_id_fk",
+          "tableFrom": "player_ranked_legend",
+          "tableTo": "player",
+          "columnsFrom": [
+            "brawlhalla_id"
+          ],
+          "columnsTo": [
+            "brawlhalla_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "player_ranked_legend_brawlhalla_id_legend_id_pk": {
+          "name": "player_ranked_legend_brawlhalla_id_legend_id_pk",
+          "columns": [
+            "brawlhalla_id",
+            "legend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_ranked_team": {
+      "name": "player_ranked_team",
+      "schema": "",
+      "columns": {
+        "brawlhalla_id": {
+          "name": "brawlhalla_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brawlhalla_id_one": {
+          "name": "brawlhalla_id_one",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brawlhalla_id_two": {
+          "name": "brawlhalla_id_two",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rating": {
+          "name": "peak_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wins": {
+          "name": "wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "games": {
+          "name": "games",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_rank": {
+          "name": "global_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valhallan_confirmed_at": {
+          "name": "valhallan_confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ranked_team_rating": {
+          "name": "idx_ranked_team_rating",
+          "columns": [
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ranked_team_region_rating": {
+          "name": "idx_ranked_team_region_rating",
+          "columns": [
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "player_ranked_team_brawlhalla_id_player_brawlhalla_id_fk": {
+          "name": "player_ranked_team_brawlhalla_id_player_brawlhalla_id_fk",
+          "tableFrom": "player_ranked_team",
+          "tableTo": "player",
+          "columnsFrom": [
+            "brawlhalla_id"
+          ],
+          "columnsTo": [
+            "brawlhalla_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "player_ranked_team_brawlhalla_id_brawlhalla_id_one_brawlhalla_id_two_pk": {
+          "name": "player_ranked_team_brawlhalla_id_brawlhalla_id_one_brawlhalla_id_two_pk",
+          "columns": [
+            "brawlhalla_id",
+            "brawlhalla_id_one",
+            "brawlhalla_id_two"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_stats_legend": {
+      "name": "player_stats_legend",
+      "schema": "",
+      "columns": {
+        "brawlhalla_id": {
+          "name": "brawlhalla_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legend_id": {
+          "name": "legend_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legend_name_key": {
+          "name": "legend_name_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xp": {
+          "name": "xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xp_percentage": {
+          "name": "xp_percentage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "games": {
+          "name": "games",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wins": {
+          "name": "wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_time": {
+          "name": "match_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kos": {
+          "name": "kos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_kos": {
+          "name": "team_kos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suicides": {
+          "name": "suicides",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "falls": {
+          "name": "falls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "damage_dealt": {
+          "name": "damage_dealt",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "damage_taken": {
+          "name": "damage_taken",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "damage_weapon_one": {
+          "name": "damage_weapon_one",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "damage_weapon_two": {
+          "name": "damage_weapon_two",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_held_weapon_one": {
+          "name": "time_held_weapon_one",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_held_weapon_two": {
+          "name": "time_held_weapon_two",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ko_weapon_one": {
+          "name": "ko_weapon_one",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ko_weapon_two": {
+          "name": "ko_weapon_two",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ko_unarmed": {
+          "name": "ko_unarmed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ko_thrown_item": {
+          "name": "ko_thrown_item",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ko_gadgets": {
+          "name": "ko_gadgets",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "damage_unarmed": {
+          "name": "damage_unarmed",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "damage_thrown_item": {
+          "name": "damage_thrown_item",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "damage_gadgets": {
+          "name": "damage_gadgets",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "player_stats_legend_brawlhalla_id_player_brawlhalla_id_fk": {
+          "name": "player_stats_legend_brawlhalla_id_player_brawlhalla_id_fk",
+          "tableFrom": "player_stats_legend",
+          "tableTo": "player",
+          "columnsFrom": [
+            "brawlhalla_id"
+          ],
+          "columnsTo": [
+            "brawlhalla_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "player_stats_legend_brawlhalla_id_legend_id_pk": {
+          "name": "player_stats_legend_brawlhalla_id_legend_id_pk",
+          "columns": [
+            "brawlhalla_id",
+            "legend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_weapon_stat": {
+      "name": "player_weapon_stat",
+      "schema": "",
+      "columns": {
+        "brawlhalla_id": {
+          "name": "brawlhalla_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weapon": {
+          "name": "weapon",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_held": {
+          "name": "time_held",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "damage": {
+          "name": "damage",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kos": {
+          "name": "kos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "player_weapon_stat_brawlhalla_id_player_brawlhalla_id_fk": {
+          "name": "player_weapon_stat_brawlhalla_id_player_brawlhalla_id_fk",
+          "tableFrom": "player_weapon_stat",
+          "tableTo": "player",
+          "columnsFrom": [
+            "brawlhalla_id"
+          ],
+          "columnsTo": [
+            "brawlhalla_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "player_weapon_stat_brawlhalla_id_weapon_pk": {
+          "name": "player_weapon_stat_brawlhalla_id_weapon_pk",
+          "columns": [
+            "brawlhalla_id",
+            "weapon"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rating_history": {
+      "name": "rating_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "brawlhalla_id": {
+          "name": "brawlhalla_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rating": {
+          "name": "peak_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "games": {
+          "name": "games",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wins": {
+          "name": "wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_rating_history_player": {
+          "name": "idx_rating_history_player",
+          "columns": [
+            {
+              "expression": "brawlhalla_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_rating_history_time": {
+          "name": "idx_rating_history_time",
+          "columns": [
+            {
+              "expression": "brawlhalla_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rating_history_brawlhalla_id_player_brawlhalla_id_fk": {
+          "name": "rating_history_brawlhalla_id_player_brawlhalla_id_fk",
+          "tableFrom": "rating_history",
+          "tableTo": "player",
+          "columnsFrom": [
+            "brawlhalla_id"
+          ],
+          "columnsTo": [
+            "brawlhalla_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_session_user_id": {
+          "name": "idx_session_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.refresh_tier": {
+      "name": "refresh_tier",
+      "schema": "public",
+      "values": [
+        "hot",
+        "warm",
+        "cold"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1773525692554,
       "tag": "0004_young_mulholland_black",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1775468100548,
+      "tag": "0005_supreme_cargill",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/relations.ts
+++ b/packages/database/src/relations.ts
@@ -2,7 +2,7 @@ import { relations } from 'drizzle-orm'
 import {
   clan,
   clanMember,
-  discordLink,
+  oauthAccount,
   player,
   playerAlias,
   playerClan,
@@ -11,6 +11,8 @@ import {
   playerStatsLegend,
   playerWeaponStat,
   ratingHistory,
+  session,
+  user,
 } from './schema'
 
 export const playerRelations = relations(player, ({ one, many }) => ({
@@ -23,10 +25,6 @@ export const playerRelations = relations(player, ({ one, many }) => ({
   }),
   rankedLegends: many(playerRankedLegend),
   rankedTeams: many(playerRankedTeam),
-  discordLink: one(discordLink, {
-    fields: [player.brawlhallaId],
-    references: [discordLink.brawlhallaId],
-  }),
   ratingHistory: many(ratingHistory),
 }))
 
@@ -83,16 +81,28 @@ export const clanMemberRelations = relations(clanMember, ({ one }) => ({
   }),
 }))
 
-export const discordLinkRelations = relations(discordLink, ({ one }) => ({
-  player: one(player, {
-    fields: [discordLink.brawlhallaId],
-    references: [player.brawlhallaId],
-  }),
-}))
-
 export const ratingHistoryRelations = relations(ratingHistory, ({ one }) => ({
   player: one(player, {
     fields: [ratingHistory.brawlhallaId],
     references: [player.brawlhallaId],
+  }),
+}))
+
+export const userRelations = relations(user, ({ many }) => ({
+  oauthAccounts: many(oauthAccount),
+  sessions: many(session),
+}))
+
+export const oauthAccountRelations = relations(oauthAccount, ({ one }) => ({
+  user: one(user, {
+    fields: [oauthAccount.userId],
+    references: [user.id],
+  }),
+}))
+
+export const sessionRelations = relations(session, ({ one }) => ({
+  user: one(user, {
+    fields: [session.userId],
+    references: [user.id],
   }),
 }))

--- a/packages/database/src/schema.ts
+++ b/packages/database/src/schema.ts
@@ -10,6 +10,7 @@ import {
   text,
   timestamp,
   uniqueIndex,
+  uuid,
   varchar,
 } from 'drizzle-orm/pg-core'
 
@@ -280,23 +281,6 @@ export const clanMember = pgTable(
 )
 
 // ============================================================
-// Discord Link
-// ============================================================
-
-export const discordLink = pgTable(
-  'discord_link',
-  {
-    discordId: varchar('discord_id', { length: 64 }).primaryKey(),
-    brawlhallaId: integer('brawlhalla_id')
-      .notNull()
-      .references(() => player.brawlhallaId, { onDelete: 'cascade' }),
-    createdAt: timestamp('created_at').defaultNow().notNull(),
-    updatedAt: timestamp('updated_at').defaultNow().notNull(),
-  },
-  (t) => [index('idx_discord_link_bhid').on(t.brawlhallaId)],
-)
-
-// ============================================================
 // Blacklist
 // ============================================================
 
@@ -328,4 +312,47 @@ export const ratingHistory = pgTable(
     index('idx_rating_history_player').on(t.brawlhallaId),
     index('idx_rating_history_time').on(t.brawlhallaId, t.recordedAt),
   ],
+)
+
+// ============================================================
+// Identity
+// ============================================================
+
+export const user = pgTable('user', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+})
+
+export const oauthAccount = pgTable(
+  'oauth_account',
+  {
+    provider: varchar('provider', { length: 32 }).notNull(),
+    providerAccountId: varchar('provider_account_id', { length: 64 }).notNull(),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => user.id, { onDelete: 'cascade' }),
+    username: varchar('username', { length: 64 }).notNull(),
+    avatarHash: varchar('avatar_hash', { length: 128 }),
+    refreshToken: text('refresh_token'),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  },
+  (t) => [
+    primaryKey({ columns: [t.provider, t.providerAccountId] }),
+    uniqueIndex('uq_oauth_account_user_provider').on(t.userId, t.provider),
+  ],
+)
+
+export const session = pgTable(
+  'session',
+  {
+    id: varchar('id', { length: 64 }).primaryKey(),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => user.id, { onDelete: 'cascade' }),
+    expiresAt: timestamp('expires_at').notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+  },
+  (t) => [index('idx_session_user_id').on(t.userId)],
 )


### PR DESCRIPTION
## Summary

- Add end-to-end Discord OAuth login: hand-rolled OAuth flow (no library), server-side sessions with SHA-256 hashed tokens, httpOnly cookies with sliding expiry
- New `@brawltome/identity` context package with User/Session types, repos, commands (`signInWithDiscord`, `signOut`), and queries (`getCurrentUser`)
- API auth routes (`/auth/discord/login`, `/auth/discord/callback`, `/auth/signout`), `identity.me` tRPC query, `protectedProcedure` middleware
- Web: `useMe` hook, sidebar + mobile avatar slots, `/account` page with sign-in/sign-out states and error banners
- Database: new `user`, `oauth_account`, `session` tables; dropped unused `discord_link`

## Test plan

- [x] 50 unit tests passing (token helpers, commands, queries, Discord client, auth routes, protected middleware, me query)
- [x] Local smoke test: full OAuth flow, session persistence, sign out, error handling
- [x] Production smoke test after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discord OAuth sign-in and sign-out with persisted server sessions and cookies
  * Account page is now a client-rendered profile view with sign-in error handling
  * Sidebar and mobile menu display user avatar and username when signed in
  * New client-side auth hook (useMe) and protected API endpoints to surface current user

* **Chores**
  * Added optional env variables for web origin and Discord OAuth/session configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->