### PR TITLE
chore: small cleanups (env docs, typed linkPlayer error, signout CSRF)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,12 @@ SESSION_COOKIE_DOMAIN=
 # Steam OpenID (account linking)
 STEAM_RETURN_URL=http://localhost:3000/auth/steam/callback
 STEAM_REALM=http://localhost:3000
+
+# Feature toggles (leave empty to enable; set to any value to disable)
+# Skip enqueuing view-refresh on player/clan GETs
+DISABLE_VIEW_REFRESH=
+# Disable the background janitor loop
+DISABLE_JANITOR=
+
+# Discord bot guild-scoped deploy (optional, skips global deploy when set)
+DISCORD_GUILD_ID=

--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,7 @@ NEXT_PUBLIC_API_URL=http://localhost:3000
 API_URL=http://localhost:3000
 DISCORD_TOKEN=
 DISCORD_CLIENT_ID=
+DISCORD_GUILD_ID=
 
 # Cloudflare Turnstile (discovery protection)
 NEXT_PUBLIC_TURNSTILE_SITE_KEY=
@@ -37,11 +38,6 @@ SESSION_COOKIE_DOMAIN=
 STEAM_RETURN_URL=http://localhost:3000/auth/steam/callback
 STEAM_REALM=http://localhost:3000
 
-# Feature toggles (leave empty to enable; set to any value to disable)
-# Skip enqueuing view-refresh on player/clan GETs
+# Disable flags (set to 1 to disable)
 DISABLE_VIEW_REFRESH=
-# Disable the background janitor loop
 DISABLE_JANITOR=
-
-# Discord bot guild-scoped deploy (optional, skips global deploy when set)
-DISCORD_GUILD_ID=

--- a/apps/api/src/auth/routes.ts
+++ b/apps/api/src/auth/routes.ts
@@ -1,6 +1,13 @@
 import { randomBytes, timingSafeEqual } from 'node:crypto'
 import type { PlayerLinkRepo, SessionRepo, UserRepo } from '@brawltome/identity'
-import { SESSION_TTL_MS, hashSessionToken, linkPlayer, signInWithDiscord, signOut } from '@brawltome/identity'
+import {
+  PlayerAlreadyLinkedError,
+  SESSION_TTL_MS,
+  hashSessionToken,
+  linkPlayer,
+  signInWithDiscord,
+  signOut,
+} from '@brawltome/identity'
 import type { Queue } from '@brawltome/shared'
 import { Hono } from 'hono'
 import {
@@ -104,6 +111,13 @@ export function createAuthRoutes(deps: CreateAuthRoutesDeps): Hono {
   })
 
   app.post('/signout', async (c) => {
+    // CSRF protection: require a custom header that cross-site forms cannot set.
+    // Session cookie is SameSite=Lax (required for OAuth redirect), so without this
+    // check, a cross-site form could log the user out.
+    if (c.req.header('x-requested-with') !== 'brawltome') {
+      return c.json({ error: 'csrf' }, 403)
+    }
+
     const cookies = parseCookies(c.req.header('cookie'))
     const raw = cookies[SESSION_COOKIE]
     if (raw) {
@@ -186,7 +200,7 @@ export function createAuthRoutes(deps: CreateAuthRoutesDeps): Hono {
       await linkPlayer({ playerLinkRepo }, { userId: session.userId, steamId })
     } catch (err) {
       console.error('[auth] linkPlayer failed', err)
-      const isAlreadyLinked = err instanceof Error && err.message.includes('already has a linked player')
+      const isAlreadyLinked = err instanceof PlayerAlreadyLinkedError
       return c.redirect(`${config.webOrigin}/account?error=${isAlreadyLinked ? 'already_linked' : 'server'}`)
     }
 

--- a/apps/api/src/auth/routes.ts
+++ b/apps/api/src/auth/routes.ts
@@ -111,10 +111,8 @@ export function createAuthRoutes(deps: CreateAuthRoutesDeps): Hono {
   })
 
   app.post('/signout', async (c) => {
-    // CSRF protection: require a custom header that cross-site forms cannot set.
-    // Session cookie is SameSite=Lax (required for OAuth redirect), so without this
-    // check, a cross-site form could log the user out.
-    if (c.req.header('x-requested-with') !== 'brawltome') {
+    const origin = c.req.header('origin')
+    if (origin !== config.webOrigin) {
       return c.json({ error: 'csrf' }, 403)
     }
 

--- a/apps/api/src/auth/routes.ts
+++ b/apps/api/src/auth/routes.ts
@@ -42,9 +42,14 @@ export interface CreateAuthRoutesDeps {
   config: AuthConfig
 }
 
+function normalizeOrigin(value: string | undefined): string {
+  return (value ?? '').trim().replace(/\/+$/, '').toLowerCase()
+}
+
 export function createAuthRoutes(deps: CreateAuthRoutesDeps): Hono {
   const app = new Hono()
   const { userRepo, sessionRepo, playerLinkRepo, steamLinkQueue, config } = deps
+  const expectedOrigin = normalizeOrigin(config.webOrigin)
 
   app.get('/discord/login', (c) => {
     const state = randomBytes(32).toString('base64url')
@@ -111,8 +116,9 @@ export function createAuthRoutes(deps: CreateAuthRoutesDeps): Hono {
   })
 
   app.post('/signout', async (c) => {
-    const origin = c.req.header('origin')
-    if (origin !== config.webOrigin) {
+    const origin = normalizeOrigin(c.req.header('origin'))
+    if (origin !== expectedOrigin) {
+      console.warn('[auth] signout rejected: origin mismatch', { origin, expected: expectedOrigin })
       return c.json({ error: 'csrf' }, 403)
     }
 

--- a/apps/api/src/router/clan.router.ts
+++ b/apps/api/src/router/clan.router.ts
@@ -24,7 +24,7 @@ export const clanRouter = router({
 
       if (ctx.isBot) return { isRefreshing: false }
 
-      if (!process.env.DISABLE_VIEW_REFRESH) {
+      if (process.env.DISABLE_VIEW_REFRESH !== '1') {
         const age = Date.now() - c.lastUpdated.getTime()
         if (age > CLAN_TTL_MS) {
           const refreshLimit = await checkRateLimit(ctx.redis, ctx.clientIp, 'refresh')

--- a/apps/api/src/router/player.router.ts
+++ b/apps/api/src/router/player.router.ts
@@ -39,7 +39,7 @@ export const playerRouter = router({
       await ctx.playerRepo.incrementViewCount(brawlhallaId)
 
       let isRefreshing = false
-      if (!process.env.DISABLE_VIEW_REFRESH) {
+      if (process.env.DISABLE_VIEW_REFRESH !== '1') {
         const ttl = TIERED_TTL.hot
 
         if (isStale(p.rankedLastUpdated, ttl.ranked)) {

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -124,9 +124,10 @@ console.log('Worker starting...')
 await initGameData(db, bhapi)
 Promise.all([rankedQueue.start(), statsQueue.start(), clanQueue.start(), steamLinkQueue.start()]).catch(console.error)
 
-const stopJanitor = process.env.DISABLE_JANITOR
-  ? async () => {}
-  : startJanitor({ db, bhapi, redis: newRedis(), rankedQueue, statsQueue, clanQueue, metrics })
+const stopJanitor =
+  process.env.DISABLE_JANITOR === '1'
+    ? async () => {}
+    : startJanitor({ db, bhapi, redis: newRedis(), rankedQueue, statsQueue, clanQueue, metrics })
 
 process.on('SIGINT', async () => {
   console.log('Worker shutting down...')

--- a/apps/api/tests/identity/auth-routes.test.ts
+++ b/apps/api/tests/identity/auth-routes.test.ts
@@ -183,7 +183,7 @@ describe('POST /auth/signout', () => {
 
     const res = await app.request('/auth/signout', {
       method: 'POST',
-      headers: { cookie: `brawltome_session=${raw}` },
+      headers: { cookie: `brawltome_session=${raw}`, 'x-requested-with': 'brawltome' },
     })
     expect(res.status).toBe(204)
     expect(fakes.sessions).toHaveLength(0)
@@ -195,7 +195,17 @@ describe('POST /auth/signout', () => {
   it('returns 204 even when there is no cookie', async () => {
     const fakes = makeFakes()
     const app = buildApp(fakes)
-    const res = await app.request('/auth/signout', { method: 'POST' })
+    const res = await app.request('/auth/signout', {
+      method: 'POST',
+      headers: { 'x-requested-with': 'brawltome' },
+    })
     expect(res.status).toBe(204)
+  })
+
+  it('rejects requests without the x-requested-with header', async () => {
+    const fakes = makeFakes()
+    const app = buildApp(fakes)
+    const res = await app.request('/auth/signout', { method: 'POST' })
+    expect(res.status).toBe(403)
   })
 })

--- a/apps/api/tests/identity/auth-routes.test.ts
+++ b/apps/api/tests/identity/auth-routes.test.ts
@@ -183,7 +183,7 @@ describe('POST /auth/signout', () => {
 
     const res = await app.request('/auth/signout', {
       method: 'POST',
-      headers: { cookie: `brawltome_session=${raw}`, 'x-requested-with': 'brawltome' },
+      headers: { cookie: `brawltome_session=${raw}`, origin: 'http://localhost:3001' },
     })
     expect(res.status).toBe(204)
     expect(fakes.sessions).toHaveLength(0)
@@ -197,12 +197,22 @@ describe('POST /auth/signout', () => {
     const app = buildApp(fakes)
     const res = await app.request('/auth/signout', {
       method: 'POST',
-      headers: { 'x-requested-with': 'brawltome' },
+      headers: { origin: 'http://localhost:3001' },
     })
     expect(res.status).toBe(204)
   })
 
-  it('rejects requests without the x-requested-with header', async () => {
+  it('rejects requests from a disallowed origin', async () => {
+    const fakes = makeFakes()
+    const app = buildApp(fakes)
+    const res = await app.request('/auth/signout', {
+      method: 'POST',
+      headers: { origin: 'http://evil.example.com' },
+    })
+    expect(res.status).toBe(403)
+  })
+
+  it('rejects requests with no origin header', async () => {
     const fakes = makeFakes()
     const app = buildApp(fakes)
     const res = await app.request('/auth/signout', { method: 'POST' })

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -47,11 +47,7 @@ export function linkSteam(): void {
 }
 
 export async function signOut(queryClient: ReturnType<typeof useQueryClient>): Promise<void> {
-  await fetch(`${apiUrl}/auth/signout`, {
-    method: 'POST',
-    credentials: 'include',
-    headers: { 'x-requested-with': 'brawltome' },
-  })
+  await fetch(`${apiUrl}/auth/signout`, { method: 'POST', credentials: 'include' })
   await queryClient.invalidateQueries({ queryKey: ME_KEY })
 }
 

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -47,7 +47,11 @@ export function linkSteam(): void {
 }
 
 export async function signOut(queryClient: ReturnType<typeof useQueryClient>): Promise<void> {
-  await fetch(`${apiUrl}/auth/signout`, { method: 'POST', credentials: 'include' })
+  await fetch(`${apiUrl}/auth/signout`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'x-requested-with': 'brawltome' },
+  })
   await queryClient.invalidateQueries({ queryKey: ME_KEY })
 }
 

--- a/packages/contexts/identity/commands/link-player.ts
+++ b/packages/contexts/identity/commands/link-player.ts
@@ -1,5 +1,12 @@
 import type { PlayerLink, PlayerLinkRepo } from '../playerLink.repo'
 
+export class PlayerAlreadyLinkedError extends Error {
+  constructor() {
+    super('User already has a linked player. Unlink first.')
+    this.name = 'PlayerAlreadyLinkedError'
+  }
+}
+
 export interface LinkPlayerDeps {
   playerLinkRepo: PlayerLinkRepo
 }
@@ -11,7 +18,7 @@ export async function linkPlayer(
   const existing = await deps.playerLinkRepo.findByUserId(params.userId)
   if (existing) {
     if (existing.status === 'linked' || existing.status === 'pending') {
-      throw new Error('User already has a linked player. Unlink first.')
+      throw new PlayerAlreadyLinkedError()
     }
     // Clear stale failed/conflict link so user can retry
     await deps.playerLinkRepo.deleteByUserId(params.userId)
@@ -22,7 +29,7 @@ export async function linkPlayer(
     // Unique constraint race: another request created a link concurrently
     const latest = await deps.playerLinkRepo.findByUserId(params.userId)
     if (latest?.status === 'linked' || latest?.status === 'pending') {
-      throw new Error('User already has a linked player. Unlink first.')
+      throw new PlayerAlreadyLinkedError()
     }
     throw err
   }

--- a/packages/contexts/identity/index.ts
+++ b/packages/contexts/identity/index.ts
@@ -18,7 +18,7 @@ export type {
 } from './commands/sign-in-with-discord'
 export { signOut } from './commands/sign-out'
 export type { SignOutDeps } from './commands/sign-out'
-export { linkPlayer } from './commands/link-player'
+export { linkPlayer, PlayerAlreadyLinkedError } from './commands/link-player'
 export type { LinkPlayerDeps } from './commands/link-player'
 export { resolveSteamLink } from './commands/resolve-steam-link'
 export type { ResolveSteamLinkDeps } from './commands/resolve-steam-link'

--- a/packages/contexts/identity/tests/commands.test.ts
+++ b/packages/contexts/identity/tests/commands.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, mock, test } from 'bun:test'
-import { linkPlayer } from '../commands/link-player'
+import { PlayerAlreadyLinkedError, linkPlayer } from '../commands/link-player'
 import { resolveSteamLink } from '../commands/resolve-steam-link'
 import { unlinkPlayer } from '../commands/unlink-player'
 import type { PlayerLinkRepo } from '../playerLink.repo'
@@ -31,7 +31,7 @@ describe('linkPlayer', () => {
     expect(repo.createPending).toHaveBeenCalledTimes(1)
   })
 
-  test('throws when user has an active linked player', async () => {
+  test('throws PlayerAlreadyLinkedError when user has an active linked player', async () => {
     const repo = mockPlayerLinkRepo({
       findByUserId: mock(async () => ({
         userId: 'user-1',
@@ -42,10 +42,12 @@ describe('linkPlayer', () => {
         linkedAt: new Date(),
       })),
     })
-    await expect(linkPlayer({ playerLinkRepo: repo }, { userId: 'user-1', steamId: '765' })).rejects.toThrow()
+    await expect(linkPlayer({ playerLinkRepo: repo }, { userId: 'user-1', steamId: '765' })).rejects.toBeInstanceOf(
+      PlayerAlreadyLinkedError,
+    )
   })
 
-  test('throws when user has a pending link', async () => {
+  test('throws PlayerAlreadyLinkedError when user has a pending link', async () => {
     const repo = mockPlayerLinkRepo({
       findByUserId: mock(async () => ({
         userId: 'user-1',
@@ -56,7 +58,9 @@ describe('linkPlayer', () => {
         linkedAt: new Date(),
       })),
     })
-    await expect(linkPlayer({ playerLinkRepo: repo }, { userId: 'user-1', steamId: '765' })).rejects.toThrow()
+    await expect(linkPlayer({ playerLinkRepo: repo }, { userId: 'user-1', steamId: '765' })).rejects.toBeInstanceOf(
+      PlayerAlreadyLinkedError,
+    )
   })
 
   test('clears stale failed link and creates new pending', async () => {


### PR DESCRIPTION
## Summary

Three small cleanups flagged during the earlier project review.

- **Document missing env vars.** `DISABLE_VIEW_REFRESH`, `DISABLE_JANITOR`, and `DISCORD_GUILD_ID` are read in code but weren't in `.env.example`. Adds them. `DISCORD_GUILD_ID` sits with the other Discord Bot vars; the disable flags get their own section.
- **Strict disable-flag parsing.** `DISABLE_VIEW_REFRESH` and `DISABLE_JANITOR` now disable only when set to `"1"`, matching the docs. Previous truthy-string semantics were easy to misuse.
- **Typed `PlayerAlreadyLinkedError`.** `apps/api/src/auth/routes.ts` previously detected "already linked" state by string-matching the error message. Replaced with a typed error class and `err instanceof` check. Tests assert the error class rather than just `toThrow`.
- **Origin-based CSRF check on `POST /auth/signout`.** The session cookie is `SameSite=Lax` (required for the OAuth redirect flow), so a cross-site form could previously log users out. Endpoint now requires the `Origin` header to match `config.webOrigin`; requests from any other origin (or with no origin) are rejected with 403. No shared secret that would be public in the source tree.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun test` passes (pre-existing `game-data.test.ts` DATABASE_URL failure is unrelated)
- [x] Local: click "sign out" in the web app, confirm 204 and session is cleared
- [x] Local: `curl -X POST http://localhost:3000/auth/signout` (no Origin header) returns 403
- [x] Local: `curl -X POST -H "Origin: http://evil.example.com" http://localhost:3000/auth/signout` returns 403

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added CSRF protection to the sign-out endpoint by validating request origins.

* **Improvements**
  * Enhanced player linking errors with more specific error detection.
  * Added new configuration variables for controlling optional features.

* **Bug Fixes**
  * Fixed feature toggle controls for view refresh and janitor processes.

* **Tests**
  * Expanded test coverage for sign-out endpoint security and player linking scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->