### PR TITLE
fix(ranking): upsert rank rows to handle cross-page player moves

### DIFF
--- a/packages/contexts/player/player.repo.ts
+++ b/packages/contexts/player/player.repo.ts
@@ -587,13 +587,22 @@ export function createPlayerRepo(db: Database) {
             ),
           )
         if (args.entries.length > 0) {
-          await tx.insert(playerRank1v1).values(
-            args.entries.map((e) => ({
-              brawlhallaId: e.brawlhallaId,
-              region: args.region,
-              rank: e.rank,
-            })),
-          )
+          await tx
+            .insert(playerRank1v1)
+            .values(
+              args.entries.map((e) => ({
+                brawlhallaId: e.brawlhallaId,
+                region: args.region,
+                rank: e.rank,
+              })),
+            )
+            .onConflictDoUpdate({
+              target: [playerRank1v1.brawlhallaId, playerRank1v1.region],
+              set: {
+                rank: sql`excluded.rank`,
+                syncedAt: sql`excluded.synced_at`,
+              },
+            })
         }
       })
     },
@@ -647,7 +656,27 @@ export function createPlayerRepo(db: Database) {
             ),
           )
         if (rowsToInsert.length > 0) {
-          await tx.insert(playerRankedTeam).values(rowsToInsert)
+          await tx
+            .insert(playerRankedTeam)
+            .values(rowsToInsert)
+            .onConflictDoUpdate({
+              target: [
+                playerRankedTeam.brawlhallaId,
+                playerRankedTeam.brawlhallaIdOne,
+                playerRankedTeam.brawlhallaIdTwo,
+                playerRankedTeam.region,
+              ],
+              set: {
+                teamName: sql`excluded.team_name`,
+                rating: sql`excluded.rating`,
+                peakRating: sql`excluded.peak_rating`,
+                tier: sql`excluded.tier`,
+                wins: sql`excluded.wins`,
+                games: sql`excluded.games`,
+                globalRank: sql`excluded.global_rank`,
+                syncedAt: sql`excluded.synced_at`,
+              },
+            })
         }
       })
     },

--- a/packages/contexts/ranking/tests/sync-rankings.rank-1v1.test.ts
+++ b/packages/contexts/ranking/tests/sync-rankings.rank-1v1.test.ts
@@ -99,4 +99,26 @@ describe('replaceRankPage1v1', () => {
     })
     expect(rows.length).toBe(1)
   })
+
+  it('handles a player moving between pages without PK conflict', async () => {
+    await playerRepo.replaceRankPage1v1({
+      region: TEST_REGION,
+      page: 1,
+      pageSize: 50,
+      entries: [{ brawlhallaId: 991001, rank: 5 }],
+    })
+
+    await playerRepo.replaceRankPage1v1({
+      region: TEST_REGION,
+      page: 2,
+      pageSize: 50,
+      entries: [{ brawlhallaId: 991001, rank: 60 }],
+    })
+
+    const rows = await db.query.playerRank1v1.findMany({
+      where: and(eq(playerRank1v1.region, TEST_REGION), eq(playerRank1v1.brawlhallaId, 991001)),
+    })
+    expect(rows.length).toBe(1)
+    expect(rows[0]?.rank).toBe(60)
+  })
 })


### PR DESCRIPTION
## Summary

Production janitor was throwing PK violations:
\`\`\`
duplicate key value violates unique constraint "player_rank_1v1_brawlhalla_id_region_pk"
Key (brawlhalla_id, region)=(2118292, all) already exists.
\`\`\`

The page-replace logic deletes by rank range only, so when a player moves between pages between syncs (e.g. was at rank 5 on page 1, now at rank 60 on page 2), the old row sticks around and the next INSERT trips the (brawlhalla_id, region) PK.

Fix: switch both \`replaceRankPage1v1\` and \`replaceRankPage2v2\` INSERTs to \`ON CONFLICT DO UPDATE\` so a player's existing row is updated to the new rank instead of conflicting.

## Test plan

- [x] New regression test: player moves from page 1 rank 5 to page 2 rank 60 — single row remains at rank 60
- [x] Existing 1v1 page-replace tests still pass
- [x] Full suite green (279 pass / 0 fail)
- [x] Typecheck + lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ranking data handling to ensure consistent updates when players appear across multiple ranking pages, preventing data inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->