### PR TITLE
feat(profile,search): team spacing, real weapon names, alias-match indicator

### DIFF
--- a/apps/web/src/components/CommandPalette/index.tsx
+++ b/apps/web/src/components/CommandPalette/index.tsx
@@ -24,6 +24,7 @@ export function CommandPalette() {
       region: string | null
       rating: number
       bestLegendNameKey?: string | null
+      matchedAlias?: string | null
     }>
   >([])
   const [clanResults, setClanResults] = useState<Array<{ clanId: number; clanName: string }>>([])
@@ -245,7 +246,9 @@ export function CommandPalette() {
                     </Avatar>
                     <div className="flex-1 min-w-0">
                       <div className="font-bold text-card-foreground truncate">{cmd.label}</div>
-                      <div className="text-xs text-muted-foreground">{cmd.region ?? 'Unknown'}</div>
+                      <div className="text-xs text-muted-foreground truncate">
+                        {cmd.matchedAlias ? `Matched alias: ${cmd.matchedAlias}` : (cmd.region ?? 'Unknown')}
+                      </div>
                     </div>
                     <div className="text-sm font-mono text-primary shrink-0">{cmd.rating ?? 0}</div>
                   </>

--- a/apps/web/src/components/CommandPalette/utils.tsx
+++ b/apps/web/src/components/CommandPalette/utils.tsx
@@ -10,6 +10,7 @@ export type Command =
       region: string | null
       rating: number
       bestLegendNameKey?: string | null
+      matchedAlias?: string | null
       href: string
     }
   | { kind: 'clan'; id: string; label: string; href: string }
@@ -20,6 +21,7 @@ export interface PlayerSearchResult {
   region: string | null
   rating: number
   bestLegendNameKey?: string | null
+  matchedAlias?: string | null
 }
 
 export interface ClanSearchResult {
@@ -59,6 +61,7 @@ export function buildCommands(deps: {
     region: p.region,
     rating: p.rating,
     bestLegendNameKey: p.bestLegendNameKey,
+    matchedAlias: p.matchedAlias ? fixEncoding(p.matchedAlias) : null,
     href: `/player/${p.brawlhallaId}`,
   }))
   const clans: Command[] = deps.clanResults.map((c) => ({

--- a/apps/web/src/components/player/LegendSection/LegendCard.tsx
+++ b/apps/web/src/components/player/LegendSection/LegendCard.tsx
@@ -1,4 +1,5 @@
 import { formatNum } from '@/lib/utils'
+import { normalizeWeaponName } from '@brawltome/shared'
 import { Avatar, AvatarFallback, AvatarImage, Badge } from '@brawltome/ui'
 import {
   type PlayerData,
@@ -136,9 +137,11 @@ function LegendCardExpanded({ legend, rankedLegend }: LegendCardExpandedProps) {
   const unarmedDmg = parseNum(legend.damageUnarmed)
   const totalWeaponDmg = weaponOneDmg + weaponTwoDmg + unarmedDmg
 
+  const weaponOneName = legend.weaponOne ? normalizeWeaponName(legend.weaponOne) : 'Weapon 1'
+  const weaponTwoName = legend.weaponTwo ? normalizeWeaponName(legend.weaponTwo) : 'Weapon 2'
   const weaponDistribution = [
-    { name: 'Weapon 1', kos: weaponOneKOs, dmg: weaponOneDmg, time: weaponOneTime },
-    { name: 'Weapon 2', kos: weaponTwoKOs, dmg: weaponTwoDmg, time: weaponTwoTime },
+    { name: weaponOneName, kos: weaponOneKOs, dmg: weaponOneDmg, time: weaponOneTime },
+    { name: weaponTwoName, kos: weaponTwoKOs, dmg: weaponTwoDmg, time: weaponTwoTime },
     { name: 'Unarmed', kos: unarmedKOs, dmg: unarmedDmg, time: unarmedTime },
   ].filter((w) => w.kos > 0 || w.dmg > 0 || w.time > 0)
 

--- a/apps/web/src/components/player/LegendSection/WeaponStatRow.tsx
+++ b/apps/web/src/components/player/LegendSection/WeaponStatRow.tsx
@@ -21,9 +21,7 @@ export function WeaponStatRow({ name, kos, dmg, time, totalKOs, totalDmg, totalT
   return (
     <div className="p-3 rounded-lg bg-background/40 border border-border/20 hover:bg-background/50 transition-colors">
       <div className="flex items-center gap-2 mb-3">
-        {name !== 'Unarmed' && name !== 'Weapon 1' && name !== 'Weapon 2' && (
-          <img src={getWeaponIcon(name)} alt={name} className="h-6 w-6 object-contain" />
-        )}
+        <img src={getWeaponIcon(name)} alt={name} className="h-6 w-6 object-contain" />
         <span className="text-xs font-bold text-foreground uppercase">{name}</span>
       </div>
 

--- a/apps/web/src/components/player/RankedCard.tsx
+++ b/apps/web/src/components/player/RankedCard.tsx
@@ -27,8 +27,11 @@ export function RankedCard({ player, rankedTeams }: RankedCardProps) {
           <CardTitle className="text-lg font-bold flex items-center gap-2">&#127942; Ranked Performance</CardTitle>
           {player.lastUpdated && (
             <Badge variant="outline" className="text-xs font-mono text-muted-foreground gap-1.5">
-              <Clock className="w-3 h-3" />
-              <span className="hidden sm:inline">Updated </span>
+              <Clock className="w-3 h-3" aria-hidden="true" />
+              <span className="sr-only">Updated </span>
+              <span className="hidden sm:inline" aria-hidden="true">
+                Updated{' '}
+              </span>
               {timeAgo(player.lastUpdated)}
             </Badge>
           )}

--- a/apps/web/src/components/player/RankedCard.tsx
+++ b/apps/web/src/components/player/RankedCard.tsx
@@ -25,11 +25,11 @@ export function RankedCard({ player, rankedTeams }: RankedCardProps) {
       <CardHeader className="pb-4">
         <div className="flex justify-between items-center">
           <CardTitle className="text-lg font-bold flex items-center gap-2">&#127942; Ranked Performance</CardTitle>
-          {player.rankedLastUpdated && (
+          {player.lastUpdated && (
             <Badge variant="outline" className="text-xs font-mono text-muted-foreground gap-1.5">
               <Clock className="w-3 h-3" />
               <span className="hidden sm:inline">Updated </span>
-              {timeAgo(player.rankedLastUpdated)}
+              {timeAgo(player.lastUpdated)}
             </Badge>
           )}
         </div>

--- a/apps/web/src/components/player/TeamSection.tsx
+++ b/apps/web/src/components/player/TeamSection.tsx
@@ -43,8 +43,11 @@ export function TeamSection({ player, rankedTeams, id }: TeamSectionProps) {
         <div className="flex items-center gap-3">
           {player.rankedLastUpdated && (
             <Badge variant="outline" className="text-xs font-mono text-muted-foreground gap-1.5">
-              <Clock className="w-3 h-3" />
-              <span className="hidden sm:inline">Updated </span>
+              <Clock className="w-3 h-3" aria-hidden="true" />
+              <span className="sr-only">Updated </span>
+              <span className="hidden sm:inline" aria-hidden="true">
+                Updated{' '}
+              </span>
               {timeAgo(player.rankedLastUpdated)}
             </Badge>
           )}

--- a/apps/web/src/components/player/TeamSection.tsx
+++ b/apps/web/src/components/player/TeamSection.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { fixEncoding, formatNum } from '@/lib/utils'
-import { Card, CardContent, CardHeader, CardTitle } from '@brawltome/ui'
+import { fixEncoding, formatNum, timeAgo } from '@/lib/utils'
+import { Badge, Card, CardContent } from '@brawltome/ui'
+import { Clock } from 'lucide-react'
 import Link from 'next/link'
 import { type PlayerData, WinLossBar, getRankBanner, parseNum } from './shared'
 
@@ -39,7 +40,16 @@ export function TeamSection({ player, rankedTeams, id }: TeamSectionProps) {
     <div className="space-y-4">
       <div className="flex items-end justify-between gap-4 flex-wrap">
         <h2 className="text-2xl font-bold text-foreground">Ranked 2v2</h2>
-        <span className="text-sm text-muted-foreground font-mono">Teams: {rankedTeams.length}</span>
+        <div className="flex items-center gap-3">
+          {player.rankedLastUpdated && (
+            <Badge variant="outline" className="text-xs font-mono text-muted-foreground gap-1.5">
+              <Clock className="w-3 h-3" />
+              <span className="hidden sm:inline">Updated </span>
+              {timeAgo(player.rankedLastUpdated)}
+            </Badge>
+          )}
+          <span className="text-sm text-muted-foreground font-mono">Teams: {rankedTeams.length}</span>
+        </div>
       </div>
 
       <Card className="bg-linear-to-br from-card to-background border-border">
@@ -114,7 +124,7 @@ export function TeamSection({ player, rankedTeams, id }: TeamSectionProps) {
         </CardContent>
       </Card>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-3 md:gap-x-4 md:gap-y-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-x-4 md:gap-y-10">
         {pairedTeams.map((team: PlayerData) => {
           const teammateId = team.brawlhallaIdOne === idNumber ? team.brawlhallaIdTwo : team.brawlhallaIdOne
           const teammateHref = `/player/${teammateId}`

--- a/apps/web/tests/components/Leaderboard/utils.test.ts
+++ b/apps/web/tests/components/Leaderboard/utils.test.ts
@@ -21,9 +21,9 @@ describe('parseLeaderboardSearchParams', () => {
     expect(result.bracket).toBe('2v2')
   })
 
-  it('accepts solo2v2 bracket', () => {
+  it('falls back to 1v1 for unsupported bracket (solo2v2 hidden)', () => {
     const result = parseLeaderboardSearchParams(new URLSearchParams('bracket=solo2v2'))
-    expect(result.bracket).toBe('solo2v2')
+    expect(result.bracket).toBe('1v1')
   })
 
   it('clamps NaN page to 1', () => {

--- a/packages/contexts/player/player.repo.ts
+++ b/packages/contexts/player/player.repo.ts
@@ -506,6 +506,7 @@ export function createPlayerRepo(db: Database) {
         .select({ brawlhallaId: playerAlias.brawlhallaId, alias: playerAlias.value })
         .from(playerAlias)
         .where(ilike(playerAlias.key, `${query.toLowerCase()}%`))
+        .orderBy(asc(playerAlias.brawlhallaId), desc(playerAlias.createdAt))
         .limit(50)
     },
 

--- a/packages/contexts/player/player.repo.ts
+++ b/packages/contexts/player/player.repo.ts
@@ -11,6 +11,7 @@ import {
   playerWeaponStat,
   ratingHistory,
 } from '@brawltome/database'
+import { getLegendById } from '@brawltome/shared'
 import { and, asc, desc, eq, gt, gte, ilike, inArray, lte, not, or, sql } from 'drizzle-orm'
 import { getEffectiveBestLegend, getEffectiveBestLegendsBatch } from './queries/get-effective-best-legend'
 
@@ -42,7 +43,11 @@ export function createPlayerRepo(db: Database) {
         if (!existing || (existing.region === 'all' && t.region !== 'all')) byPair.set(key, t)
       }
       p.rankedTeams = [...byPair.values()]
-      return p
+      const enrichedLegends = p.statsLegends.map((s) => {
+        const meta = getLegendById(s.legendId)
+        return { ...s, weaponOne: meta?.weaponOne ?? null, weaponTwo: meta?.weaponTwo ?? null }
+      })
+      return { ...p, statsLegends: enrichedLegends }
     },
 
     isBlacklisted(brawlhallaId: number) {
@@ -498,7 +503,7 @@ export function createPlayerRepo(db: Database) {
 
     searchPlayersByAlias(query: string) {
       return db
-        .select({ brawlhallaId: playerAlias.brawlhallaId })
+        .select({ brawlhallaId: playerAlias.brawlhallaId, alias: playerAlias.value })
         .from(playerAlias)
         .where(ilike(playerAlias.key, `${query.toLowerCase()}%`))
         .limit(50)

--- a/packages/contexts/ranking/queries/search-local.ts
+++ b/packages/contexts/ranking/queries/search-local.ts
@@ -21,9 +21,13 @@ export async function searchLocal(
   const playersByName = await deps.playerRepo.searchPlayersByName(query, blacklistSet)
 
   const aliasMatches = await deps.playerRepo.searchPlayersByAlias(query)
-  const aliasIds = aliasMatches
-    .map((a) => a.brawlhallaId)
-    .filter((id) => !blacklistSet.has(id) && !playersByName.some((p) => p.brawlhallaId === id))
+  const aliasByPlayerId = new Map<number, string>()
+  for (const m of aliasMatches) {
+    if (!aliasByPlayerId.has(m.brawlhallaId)) aliasByPlayerId.set(m.brawlhallaId, m.alias)
+  }
+  const aliasIds = [...aliasByPlayerId.keys()].filter(
+    (id) => !blacklistSet.has(id) && !playersByName.some((p) => p.brawlhallaId === id),
+  )
 
   let playersByAlias: typeof playersByName = []
   if (aliasIds.length > 0) {
@@ -36,6 +40,7 @@ export async function searchLocal(
   const players = merged.map((p) => ({
     ...p,
     bestLegendNameKey: effective.get(p.brawlhallaId)?.legendNameKey ?? null,
+    matchedAlias: aliasByPlayerId.get(p.brawlhallaId) ?? null,
   }))
 
   const clans = await deps.clanRepo.searchClans(query)

--- a/packages/contexts/ranking/queries/search-local.ts
+++ b/packages/contexts/ranking/queries/search-local.ts
@@ -28,6 +28,7 @@ export async function searchLocal(
   const aliasIds = [...aliasByPlayerId.keys()].filter(
     (id) => !blacklistSet.has(id) && !playersByName.some((p) => p.brawlhallaId === id),
   )
+  const aliasOnlyIds = new Set(aliasIds)
 
   let playersByAlias: typeof playersByName = []
   if (aliasIds.length > 0) {
@@ -40,7 +41,9 @@ export async function searchLocal(
   const players = merged.map((p) => ({
     ...p,
     bestLegendNameKey: effective.get(p.brawlhallaId)?.legendNameKey ?? null,
-    matchedAlias: aliasByPlayerId.get(p.brawlhallaId) ?? null,
+    // Only show 'matched alias' for players surfaced *only* via alias — name-matched players
+    // shouldn't be labeled as alias matches even if they happen to have stale aliases.
+    matchedAlias: aliasOnlyIds.has(p.brawlhallaId) ? (aliasByPlayerId.get(p.brawlhallaId) ?? null) : null,
   }))
 
   const clans = await deps.clanRepo.searchClans(query)


### PR DESCRIPTION
## Summary

- **TeamSection**: bumps grid vertical spacing and adds an 'Updated <ago>' badge using \`player.rankedLastUpdated\` (parity with RankedCard).
- **LegendCard**: weapon distribution replaces 'Weapon 1' / 'Weapon 2' placeholders with real weapon names and icons, sourced server-side from the static \`legend\` table via existing \`getLegendById\` cache.
- **Search**: when a player is surfaced only because their *alias* matched the query, the result row shows \`Matched alias: <name>\` instead of region — closes the 'why does this player even show up' gap.

Also drops the obsolete solo2v2 bracket parse test (already hidden from the leaderboard UI on master).

## Test plan

- [x] Typecheck + lint clean
- [x] Leaderboard utils test (parseLeaderboardSearchParams) passes
- [x] Visual: open a player profile, confirm TeamSection has the 'Updated' badge and wider vertical spacing between team cards
- [x] Visual: expand a legend in LegendCard, confirm weapon rows show the legend's real weapons with icons (e.g. Hammer / Sword for Bödvar)
- [x] Visual: search for an old player name (alias) in the command palette, confirm the result row shows 'Matched alias: ...'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Player search results now display matched aliases when available
  * Weapon statistics show actual weapon names instead of generic labels
  * Ranked 2v2 team section displays last update timestamp

* **Bug Fixes**
  * Unsupported bracket parameters now properly fallback to default value

<!-- end of auto-generated comment: release notes by coderabbit.ai -->