### PR TITLE
fix(ranking): plug page-2 leak, cap depth at 2000, region casing constraint

### DIFF
--- a/apps/api/scripts/reset-rank-cursors.ts
+++ b/apps/api/scripts/reset-rank-cursors.ts
@@ -1,0 +1,28 @@
+import Redis from 'ioredis'
+
+const REGIONS = ['us-e', 'eu', 'sea', 'brz', 'aus', 'us-w', 'jpn', 'me', 'sa'] as const
+
+async function main() {
+  const url = process.env.REDIS_URL
+  if (!url) {
+    console.error('REDIS_URL is not set')
+    process.exit(1)
+  }
+  const redis = new Redis(url)
+
+  const keys: string[] = ['cursor:cold:1v1', 'cursor:cold:2v2']
+  for (const r of REGIONS) {
+    keys.push(`cursor:region:1v1:${r}`)
+    keys.push(`cursor:region:2v2:${r}`)
+  }
+
+  const removed = await redis.del(...keys)
+  console.log(`Deleted ${removed} cursor keys (out of ${keys.length} requested)`)
+
+  await redis.quit()
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/apps/web/src/components/Leaderboard/utils.ts
+++ b/apps/web/src/components/Leaderboard/utils.ts
@@ -30,7 +30,7 @@ export const BRACKET_IDS = BRACKETS.map((b) => b.id) as readonly BracketId[]
 export const REGION_IDS = REGIONS.map((r) => r.id) as readonly RegionId[]
 
 export const PAGE_SIZE = 20
-export const MAX_PAGE = 200
+export const MAX_PAGE = 100
 
 export interface LeaderboardFilters {
   bracket: BracketId

--- a/apps/web/tests/components/Leaderboard/utils.test.ts
+++ b/apps/web/tests/components/Leaderboard/utils.test.ts
@@ -33,7 +33,7 @@ describe('parseLeaderboardSearchParams', () => {
 
   it('clamps page to max', () => {
     const result = parseLeaderboardSearchParams(new URLSearchParams('page=9999'))
-    expect(result.page).toBe(200)
+    expect(result.page).toBe(100)
   })
 
   it('clamps page below 1 to 1', () => {

--- a/packages/contexts/player/player.repo.ts
+++ b/packages/contexts/player/player.repo.ts
@@ -670,10 +670,17 @@ export function createPlayerRepo(db: Database) {
         games: number
         globalRank: number
       }>
-    }) {
+    }): Promise<{ vacatedSourcePages: number[] }> {
       const minRank = (args.page - 1) * args.pageSize + 1
       const maxRank = args.page * args.pageSize
       const region = normalizeRegion(args.region)
+
+      const batchOwnerIds = new Set<number>()
+      for (const t of args.teams) {
+        batchOwnerIds.add(t.brawlhallaIdOne)
+        batchOwnerIds.add(t.brawlhallaIdTwo)
+      }
+      const ownerIdList = [...batchOwnerIds]
 
       const rowsToInsert: Array<typeof playerRankedTeam.$inferInsert> = []
       for (const t of args.teams) {
@@ -696,7 +703,35 @@ export function createPlayerRepo(db: Database) {
         }
       }
 
-      await db.transaction(async (tx) => {
+      return await db.transaction(async (tx) => {
+        const moverRows =
+          ownerIdList.length > 0
+            ? await tx
+                .select({
+                  one: playerRankedTeam.brawlhallaIdOne,
+                  two: playerRankedTeam.brawlhallaIdTwo,
+                  rank: playerRankedTeam.globalRank,
+                })
+                .from(playerRankedTeam)
+                .where(
+                  and(
+                    eq(playerRankedTeam.region, region),
+                    inArray(playerRankedTeam.brawlhallaId, ownerIdList),
+                    or(lt(playerRankedTeam.globalRank, minRank), gt(playerRankedTeam.globalRank, maxRank)),
+                  ),
+                )
+            : []
+        const teamSourcePages = new Set<number>()
+        const seenTeams = new Set<string>()
+        for (const r of moverRows) {
+          if (r.rank == null || r.rank <= 0) continue
+          const key = `${Math.min(r.one, r.two)}:${Math.max(r.one, r.two)}`
+          if (seenTeams.has(key)) continue
+          seenTeams.add(key)
+          teamSourcePages.add(Math.ceil(r.rank / args.pageSize))
+        }
+        const vacatedSourcePages = [...teamSourcePages]
+
         await tx
           .delete(playerRankedTeam)
           .where(
@@ -729,6 +764,8 @@ export function createPlayerRepo(db: Database) {
               },
             })
         }
+
+        return { vacatedSourcePages }
       })
     },
 

--- a/packages/contexts/player/player.repo.ts
+++ b/packages/contexts/player/player.repo.ts
@@ -12,7 +12,7 @@ import {
   ratingHistory,
 } from '@brawltome/database'
 import { getLegendById } from '@brawltome/shared'
-import { and, asc, desc, eq, gt, gte, ilike, inArray, lte, not, or, sql } from 'drizzle-orm'
+import { and, asc, desc, eq, gt, gte, ilike, inArray, lt, lte, not, or, sql } from 'drizzle-orm'
 import { getEffectiveBestLegend, getEffectiveBestLegendsBatch } from './queries/get-effective-best-legend'
 
 const normalizeRegion = (region: string) => (region === 'all' ? 'all' : region.toUpperCase())
@@ -606,16 +606,28 @@ export function createPlayerRepo(db: Database) {
       page: number
       pageSize: number
       entries: Array<{ brawlhallaId: number; rank: number }>
-    }) {
+    }): Promise<{ vacatedSourcePages: number[] }> {
       const minRank = (args.page - 1) * args.pageSize + 1
       const maxRank = args.page * args.pageSize
       const region = normalizeRegion(args.region)
       const batchIds = args.entries.map((e) => e.brawlhallaId)
-      await db.transaction(async (tx) => {
-        // Two clauses: clear the rank slot, AND clear any row for a player in the new batch
-        // that may live on another page. Without the second clause, a cross-page mover would
-        // collide with their existing row and an ON-CONFLICT-UPDATE would collapse two INSERT
-        // rows into one — leaving a gap in the destination page (e.g. EU page 2 at 49 rows).
+
+      return await db.transaction(async (tx) => {
+        const moverRows =
+          batchIds.length > 0
+            ? await tx
+                .select({ rank: playerRank1v1.rank })
+                .from(playerRank1v1)
+                .where(
+                  and(
+                    eq(playerRank1v1.region, region),
+                    inArray(playerRank1v1.brawlhallaId, batchIds),
+                    or(lt(playerRank1v1.rank, minRank), gt(playerRank1v1.rank, maxRank)),
+                  ),
+                )
+            : []
+        const vacatedSourcePages = [...new Set(moverRows.map((m) => Math.ceil(m.rank / args.pageSize)))]
+
         await tx
           .delete(playerRank1v1)
           .where(
@@ -638,6 +650,8 @@ export function createPlayerRepo(db: Database) {
             })),
           )
         }
+
+        return { vacatedSourcePages }
       })
     },
 

--- a/packages/contexts/ranking/commands/sync-rankings.ts
+++ b/packages/contexts/ranking/commands/sync-rankings.ts
@@ -6,8 +6,9 @@ import type { Redis } from 'ioredis'
 import { JANITOR_MIN_TOKENS } from '../ranking'
 
 const REGIONS: Region[] = ['us-e', 'eu', 'sea', 'brz', 'aus', 'us-w', 'jpn', 'me', 'sa']
-const HOT_PAGES = 10
-const MAX_COLD_PAGE = 200
+export const HOT_PAGES = 10
+export const MAX_COLD_PAGE = 40
+export const HOT_REGIONAL_PAGES = 2
 const COLD_TICK_INTERVAL = 10
 const LOCK_KEY = 'janitor:lock'
 const LOCK_TTL_SEC = 60
@@ -92,25 +93,27 @@ export function startJanitor(deps: JanitorDeps) {
         )
       }
 
-      // Hot regional: refresh page 1 of one region per tick. Each region's top 50 stays fresh
-      // within ~9 minutes instead of the ~30 hours it'd take via cold rotation alone.
+      // Hot regional: refresh pages 1-2 of one region per tick. Each region's top 100 stays fresh
+      // within ~18 minutes instead of the ~30 hours it'd take via cold rotation alone.
       const hotRegionIndex = (tick - 1) % REGIONS.length
       const hotRegion = REGIONS[hotRegionIndex]
-      await time(`hot 1v1 ${hotRegion}`, () =>
-        sync1v1Page(deps, playerRepo, hotRegion, 1, 1, `cursor:region:hot:1v1:${hotRegion}`, lockState),
-      )
-      await time(`hot 2v2 ${hotRegion}`, () =>
-        sync2v2Page(deps, playerRepo, hotRegion, 1, 1, `cursor:region:hot:2v2:${hotRegion}`, lockState),
-      )
+      for (let p = 1; p <= HOT_REGIONAL_PAGES; p++) {
+        await time(`hot 1v1 ${hotRegion} p${p}`, () =>
+          sync1v1Page(deps, playerRepo, hotRegion, p, p, `cursor:region:hot:1v1:${hotRegion}:p${p}`, lockState),
+        )
+        await time(`hot 2v2 ${hotRegion} p${p}`, () =>
+          sync2v2Page(deps, playerRepo, hotRegion, p, p, `cursor:region:hot:2v2:${hotRegion}:p${p}`, lockState),
+        )
+      }
 
-      // Cold regional: rotate 1 region per tick across pages 2..MAX_COLD_PAGE.
+      // Cold regional: rotate 1 region per tick across pages HOT_REGIONAL_PAGES+1..MAX_COLD_PAGE.
       const coldRegionIndex = (tick - 1) % REGIONS.length
       const coldRegion = REGIONS[coldRegionIndex]
       await time(`1v1 ${coldRegion}`, () =>
-        sync1v1Page(deps, playerRepo, coldRegion, 2, MAX_COLD_PAGE, `cursor:region:1v1:${coldRegion}`, lockState),
+        sync1v1Page(deps, playerRepo, coldRegion, HOT_REGIONAL_PAGES + 1, MAX_COLD_PAGE, `cursor:region:1v1:${coldRegion}`, lockState),
       )
       await time(`2v2 ${coldRegion}`, () =>
-        sync2v2Page(deps, playerRepo, coldRegion, 2, MAX_COLD_PAGE, `cursor:region:2v2:${coldRegion}`, lockState),
+        sync2v2Page(deps, playerRepo, coldRegion, HOT_REGIONAL_PAGES + 1, MAX_COLD_PAGE, `cursor:region:2v2:${coldRegion}`, lockState),
       )
 
       const elapsed = ((performance.now() - tickStart) / 1000).toFixed(1)

--- a/packages/contexts/ranking/commands/sync-rankings.ts
+++ b/packages/contexts/ranking/commands/sync-rankings.ts
@@ -73,6 +73,11 @@ export function startJanitor(deps: JanitorDeps) {
     }
 
     try {
+      // Drain pending resyncs first so vacated source pages get re-fetched promptly.
+      // drainResyncQueue respects token + time budget internally, so it's safe to run before the tick skip check.
+      await time('drain 1v1 resync', () => drainResyncQueue(deps, playerRepo, '1v1', lockState, tickStart))
+      await time('drain 2v2 resync', () => drainResyncQueue(deps, playerRepo, '2v2', lockState, tickStart))
+
       const tokens = deps.bhapi.remainingTokens('background')
       if (tokens < JANITOR_MIN_TOKENS) {
         console.log(`[janitor] tick ${tick} skipped: only ${tokens} tokens remaining`)
@@ -110,10 +115,26 @@ export function startJanitor(deps: JanitorDeps) {
       const coldRegionIndex = (tick - 1) % REGIONS.length
       const coldRegion = REGIONS[coldRegionIndex]
       await time(`1v1 ${coldRegion}`, () =>
-        sync1v1Page(deps, playerRepo, coldRegion, HOT_REGIONAL_PAGES + 1, MAX_COLD_PAGE, `cursor:region:1v1:${coldRegion}`, lockState),
+        sync1v1Page(
+          deps,
+          playerRepo,
+          coldRegion,
+          HOT_REGIONAL_PAGES + 1,
+          MAX_COLD_PAGE,
+          `cursor:region:1v1:${coldRegion}`,
+          lockState,
+        ),
       )
       await time(`2v2 ${coldRegion}`, () =>
-        sync2v2Page(deps, playerRepo, coldRegion, HOT_REGIONAL_PAGES + 1, MAX_COLD_PAGE, `cursor:region:2v2:${coldRegion}`, lockState),
+        sync2v2Page(
+          deps,
+          playerRepo,
+          coldRegion,
+          HOT_REGIONAL_PAGES + 1,
+          MAX_COLD_PAGE,
+          `cursor:region:2v2:${coldRegion}`,
+          lockState,
+        ),
       )
 
       const elapsed = ((performance.now() - tickStart) / 1000).toFixed(1)
@@ -194,12 +215,7 @@ function normalizeRegionKey(region: Region | 'all'): string {
   return region === 'all' ? 'all' : region.toUpperCase()
 }
 
-async function enqueueResyncs(
-  redis: Redis,
-  bracket: '1v1' | '2v2',
-  region: Region | 'all',
-  pages: number[],
-) {
+async function enqueueResyncs(redis: Redis, bracket: '1v1' | '2v2', region: Region | 'all', pages: number[]) {
   const filtered = pages.filter((p) => shouldEnqueueSourcePage(p, region))
   if (filtered.length === 0) return
   const regionKey = normalizeRegionKey(region)
@@ -284,6 +300,59 @@ export async function sync2v2Page(
   if (cursorKey !== null) {
     const nextPage = page + 1 > maxPage ? startPage : page + 1
     await deps.redis.set(cursorKey, String(nextPage))
+  }
+}
+
+const TICK_BUDGET_MS = 30_000
+
+export async function drainResyncQueue(
+  deps: JanitorDeps,
+  playerRepo: PlayerRepo,
+  bracket: '1v1' | '2v2',
+  lockState: LockState,
+  tickStart: number,
+) {
+  const queueKey = `resync:${bracket}:queue`
+  const members = await deps.redis.smembers(queueKey)
+  if (members.length === 0) return
+  // SMEMBERS + DEL is safe under single-instance lock — no other writer between read and delete.
+  await deps.redis.del(queueKey)
+
+  const remaining: string[] = []
+  for (let i = 0; i < members.length; i++) {
+    if (lockState.lost) {
+      remaining.push(...members.slice(i))
+      break
+    }
+    if (deps.bhapi.remainingTokens('background') < JANITOR_MIN_TOKENS) {
+      remaining.push(...members.slice(i))
+      break
+    }
+    if (performance.now() - tickStart > TICK_BUDGET_MS) {
+      remaining.push(...members.slice(i))
+      break
+    }
+    const member = members[i]
+    if (!member) continue
+    const sep = member.indexOf(':')
+    if (sep < 0) continue
+    const region = member.slice(0, sep) as Region | 'all'
+    const page = Number.parseInt(member.slice(sep + 1), 10)
+    if (!Number.isFinite(page)) continue
+    try {
+      if (bracket === '1v1') {
+        await sync1v1Page(deps, playerRepo, region, page, page, null, lockState, { depth: 1 })
+      } else {
+        await sync2v2Page(deps, playerRepo, region, page, page, null, lockState, { depth: 1 })
+      }
+    } catch (err) {
+      console.error(`[janitor] resync failed ${bracket} ${member}:`, err)
+      await deps.metrics?.incrementCounter('janitor:resync_failures').catch(() => {})
+    }
+  }
+
+  if (remaining.length > 0) {
+    await deps.redis.sadd(queueKey, ...remaining)
   }
 }
 

--- a/packages/contexts/ranking/commands/sync-rankings.ts
+++ b/packages/contexts/ranking/commands/sync-rankings.ts
@@ -182,37 +182,46 @@ async function advanceCursor(redis: Redis, cursorKey: string, startPage: number,
   return cursor ? Math.max(startPage, Math.min(Number.parseInt(cursor, 10), maxPage)) : startPage
 }
 
+export type SyncPageOpts = { depth: 0 | 1 }
+
 export async function sync1v1Page(
   deps: JanitorDeps,
   playerRepo: PlayerRepo,
   region: Region | 'all',
   startPage: number,
   maxPage: number,
-  cursorKey: string,
+  cursorKey: string | null,
   lockState: LockState,
+  opts: SyncPageOpts = { depth: 0 },
 ) {
   if (lockState.lost) throw new Error('janitor lock lost during tick')
-  const page = await advanceCursor(deps.redis, cursorKey, startPage, maxPage)
+  const page = cursorKey === null ? startPage : await advanceCursor(deps.redis, cursorKey, startPage, maxPage)
   if (deps.bhapi.remainingTokens('background') < JANITOR_MIN_TOKENS) return
 
   const rankings = await deps.bhapi.getRankings1v1(region as Region, page, { caller: 'background' })
 
   if (rankings.length === 0) {
-    await deps.redis.set(cursorKey, String(startPage))
+    if (cursorKey !== null) await deps.redis.set(cursorKey, String(startPage))
     return
   }
 
   await savePlayers(playerRepo, rankings, deps.metrics)
-  await playerRepo.replaceRankPage1v1({
+  // result.vacatedSourcePages and opts.depth are consumed by source-page enqueue logic in Task 6.
+  // depth=0 (top-level tick): enqueue resyncs. depth=1 (drained from queue): skip to guarantee termination.
+  const result = await playerRepo.replaceRankPage1v1({
     region,
     page,
     pageSize: 50,
     entries: rankings.map((r) => ({ brawlhallaId: r.brawlhalla_id, rank: r.rank })),
   })
   console.log(`[janitor] 1v1 ${region} page ${page}: ${rankings.length} players`)
+  void opts
+  void result
 
-  const nextPage = page + 1 > maxPage ? startPage : page + 1
-  await deps.redis.set(cursorKey, String(nextPage))
+  if (cursorKey !== null) {
+    const nextPage = page + 1 > maxPage ? startPage : page + 1
+    await deps.redis.set(cursorKey, String(nextPage))
+  }
 }
 
 export async function sync2v2Page(
@@ -221,25 +230,31 @@ export async function sync2v2Page(
   region: Region | 'all',
   startPage: number,
   maxPage: number,
-  cursorKey: string,
+  cursorKey: string | null,
   lockState: LockState,
+  opts: SyncPageOpts = { depth: 0 },
 ) {
   if (lockState.lost) throw new Error('janitor lock lost during tick')
-  const page = await advanceCursor(deps.redis, cursorKey, startPage, maxPage)
+  const page = cursorKey === null ? startPage : await advanceCursor(deps.redis, cursorKey, startPage, maxPage)
   if (deps.bhapi.remainingTokens('background') < JANITOR_MIN_TOKENS) return
 
   const rankings = await deps.bhapi.getRankings2v2(region as Region, page, { caller: 'background' })
 
   if (rankings.length === 0) {
-    await deps.redis.set(cursorKey, String(startPage))
+    if (cursorKey !== null) await deps.redis.set(cursorKey, String(startPage))
     return
   }
 
-  await saveTeams(playerRepo, rankings, region, page, deps.metrics)
+  // result.vacatedSourcePages and opts.depth are consumed by source-page enqueue logic in Task 6.
+  const result = await saveTeams(playerRepo, rankings, region, page, deps.metrics)
   console.log(`[janitor] 2v2 ${region} page ${page}: ${rankings.length} teams`)
+  void opts
+  void result
 
-  const nextPage = page + 1 > maxPage ? startPage : page + 1
-  await deps.redis.set(cursorKey, String(nextPage))
+  if (cursorKey !== null) {
+    const nextPage = page + 1 > maxPage ? startPage : page + 1
+    await deps.redis.set(cursorKey, String(nextPage))
+  }
 }
 
 async function withSaveFailureMetric<T>(
@@ -295,7 +310,7 @@ export async function saveTeams(
   region: string,
   page: number,
   metrics: MetricsRegistry | undefined,
-) {
+): Promise<{ vacatedSourcePages: number[] }> {
   const seenPlayers = new Set<number>()
   const playerRows: Array<{ brawlhallaId: number; name: string; region: string | null; rating: number }> = []
   for (const r of rankings) {
@@ -341,9 +356,9 @@ export async function saveTeams(
     })
   }
 
-  await withSaveFailureMetric(metrics, '2v2', async () => {
+  return await withSaveFailureMetric(metrics, '2v2', async () => {
     await repo.batchUpsertPlaceholderPlayers(playerRows)
-    await repo.replaceRankPage2v2({
+    return await repo.replaceRankPage2v2({
       region,
       page,
       pageSize: 50,

--- a/packages/contexts/ranking/commands/sync-rankings.ts
+++ b/packages/contexts/ranking/commands/sync-rankings.ts
@@ -313,30 +313,22 @@ export async function drainResyncQueue(
   tickStart: number,
 ) {
   const queueKey = `resync:${bracket}:queue`
-  const members = await deps.redis.smembers(queueKey)
-  if (members.length === 0) return
-  // SMEMBERS + DEL is safe under single-instance lock — no other writer between read and delete.
-  await deps.redis.del(queueKey)
+  // SPOP per iteration: each entry leaves the set only after we own it. A crash mid-loop
+  // loses at most the in-flight entry, not the rest of the backlog. Budget guards (lock,
+  // tokens, wall clock) check FIRST so we don't pop entries we won't process.
+  while (true) {
+    if (lockState.lost) break
+    if (deps.bhapi.remainingTokens('background') < JANITOR_MIN_TOKENS) break
+    if (performance.now() - tickStart > TICK_BUDGET_MS) break
 
-  const remaining: string[] = []
-  for (let i = 0; i < members.length; i++) {
-    if (lockState.lost) {
-      remaining.push(...members.slice(i))
-      break
-    }
-    if (deps.bhapi.remainingTokens('background') < JANITOR_MIN_TOKENS) {
-      remaining.push(...members.slice(i))
-      break
-    }
-    if (performance.now() - tickStart > TICK_BUDGET_MS) {
-      remaining.push(...members.slice(i))
-      break
-    }
-    const member = members[i]
-    if (!member) continue
+    const member = await deps.redis.spop(queueKey)
+    if (!member) break
+
     const sep = member.indexOf(':')
     if (sep < 0) continue
-    const region = member.slice(0, sep) as Region | 'all'
+    const rawRegion = member.slice(0, sep)
+    // Queue members are stored uppercase via normalizeRegionKey; BHAPI region paths are lowercase.
+    const region = rawRegion === 'all' ? 'all' : (rawRegion.toLowerCase() as Region)
     const page = Number.parseInt(member.slice(sep + 1), 10)
     if (!Number.isFinite(page)) continue
     try {
@@ -349,10 +341,6 @@ export async function drainResyncQueue(
       console.error(`[janitor] resync failed ${bracket} ${member}:`, err)
       await deps.metrics?.incrementCounter('janitor:resync_failures').catch(() => {})
     }
-  }
-
-  if (remaining.length > 0) {
-    await deps.redis.sadd(queueKey, ...remaining)
   }
 }
 

--- a/packages/contexts/ranking/commands/sync-rankings.ts
+++ b/packages/contexts/ranking/commands/sync-rankings.ts
@@ -182,6 +182,31 @@ async function advanceCursor(redis: Redis, cursorKey: string, startPage: number,
   return cursor ? Math.max(startPage, Math.min(Number.parseInt(cursor, 10), maxPage)) : startPage
 }
 
+function shouldEnqueueSourcePage(page: number, region: Region | 'all'): boolean {
+  if (page > MAX_COLD_PAGE) return false
+  // 'all' has its own hot zone (HOT_PAGES = 10); regional has HOT_REGIONAL_PAGES = 2.
+  const hotZone = region === 'all' ? HOT_PAGES : HOT_REGIONAL_PAGES
+  if (page <= hotZone) return false
+  return true
+}
+
+function normalizeRegionKey(region: Region | 'all'): string {
+  return region === 'all' ? 'all' : region.toUpperCase()
+}
+
+async function enqueueResyncs(
+  redis: Redis,
+  bracket: '1v1' | '2v2',
+  region: Region | 'all',
+  pages: number[],
+) {
+  const filtered = pages.filter((p) => shouldEnqueueSourcePage(p, region))
+  if (filtered.length === 0) return
+  const regionKey = normalizeRegionKey(region)
+  const members = filtered.map((p) => `${regionKey}:${p}`)
+  await redis.sadd(`resync:${bracket}:queue`, ...members)
+}
+
 export type SyncPageOpts = { depth: 0 | 1 }
 
 export async function sync1v1Page(
@@ -206,8 +231,8 @@ export async function sync1v1Page(
   }
 
   await savePlayers(playerRepo, rankings, deps.metrics)
-  // result.vacatedSourcePages and opts.depth are consumed by source-page enqueue logic in Task 6.
-  // depth=0 (top-level tick): enqueue resyncs. depth=1 (drained from queue): skip to guarantee termination.
+  // depth=0 (top-level tick): enqueue resyncs for vacated source pages.
+  // depth=1 (drained from queue): skip enqueueing to guarantee termination.
   const result = await playerRepo.replaceRankPage1v1({
     region,
     page,
@@ -215,8 +240,10 @@ export async function sync1v1Page(
     entries: rankings.map((r) => ({ brawlhallaId: r.brawlhalla_id, rank: r.rank })),
   })
   console.log(`[janitor] 1v1 ${region} page ${page}: ${rankings.length} players`)
-  void opts
-  void result
+
+  if (opts.depth === 0 && result.vacatedSourcePages.length > 0) {
+    await enqueueResyncs(deps.redis, '1v1', region, result.vacatedSourcePages)
+  }
 
   if (cursorKey !== null) {
     const nextPage = page + 1 > maxPage ? startPage : page + 1
@@ -245,11 +272,14 @@ export async function sync2v2Page(
     return
   }
 
-  // result.vacatedSourcePages and opts.depth are consumed by source-page enqueue logic in Task 6.
+  // depth=0 (top-level tick): enqueue resyncs for vacated source pages.
+  // depth=1 (drained from queue): skip enqueueing to guarantee termination.
   const result = await saveTeams(playerRepo, rankings, region, page, deps.metrics)
   console.log(`[janitor] 2v2 ${region} page ${page}: ${rankings.length} teams`)
-  void opts
-  void result
+
+  if (opts.depth === 0 && result.vacatedSourcePages.length > 0) {
+    await enqueueResyncs(deps.redis, '2v2', region, result.vacatedSourcePages)
+  }
 
   if (cursorKey !== null) {
     const nextPage = page + 1 > maxPage ? startPage : page + 1

--- a/packages/contexts/ranking/tests/get-leaderboard.rank.test.ts
+++ b/packages/contexts/ranking/tests/get-leaderboard.rank.test.ts
@@ -5,7 +5,7 @@ import { eq, inArray } from 'drizzle-orm'
 import { getLeaderboard } from '../queries/get-leaderboard'
 import { createRankingRepo } from '../ranking.repo'
 
-const TEST_REGION = 'test-lb'
+const TEST_REGION = 'TEST-LB'
 const TEST_IDS = Array.from({ length: 30 }, (_, i) => 993000 + i)
 
 const playerRepo = createPlayerRepo(db)

--- a/packages/contexts/ranking/tests/sync-rankings.rank-1v1.test.ts
+++ b/packages/contexts/ranking/tests/sync-rankings.rank-1v1.test.ts
@@ -170,4 +170,61 @@ describe('replaceRankPage1v1', () => {
     expect(upper.length).toBe(1)
     expect(lower.length).toBe(0)
   })
+
+  it('returns empty vacatedSourcePages when no batch ID exists outside the page range', async () => {
+    await db.delete(playerRank1v1).where(eq(playerRank1v1.region, TEST_REGION))
+
+    const result = await playerRepo.replaceRankPage1v1({
+      region: TEST_REGION,
+      page: 1,
+      pageSize: 50,
+      entries: [
+        { brawlhallaId: 991001, rank: 1 },
+        { brawlhallaId: 991002, rank: 2 },
+      ],
+    })
+
+    expect(result.vacatedSourcePages).toEqual([])
+  })
+
+  it('returns distinct source pages when batch IDs span multiple foreign pages', async () => {
+    await db.delete(playerRank1v1).where(eq(playerRank1v1.region, TEST_REGION))
+
+    // Seed: 991001 at rank 5 (page 1), 991002 at rank 60 (page 2), 991003 at rank 105 (page 3)
+    await db.insert(playerRank1v1).values([
+      { brawlhallaId: 991001, region: TEST_REGION, rank: 5 },
+      { brawlhallaId: 991002, region: TEST_REGION, rank: 60 },
+      { brawlhallaId: 991003, region: TEST_REGION, rank: 105 },
+    ])
+
+    // Sync page 4 (ranks 151-200) with all three IDs at new ranks within the page
+    const result = await playerRepo.replaceRankPage1v1({
+      region: TEST_REGION,
+      page: 4,
+      pageSize: 50,
+      entries: [
+        { brawlhallaId: 991001, rank: 151 },
+        { brawlhallaId: 991002, rank: 152 },
+        { brawlhallaId: 991003, rank: 153 },
+      ],
+    })
+
+    expect(result.vacatedSourcePages.sort()).toEqual([1, 2, 3])
+  })
+
+  it('does not list the current page as a vacated source page', async () => {
+    await db.delete(playerRank1v1).where(eq(playerRank1v1.region, TEST_REGION))
+
+    // 991001 currently at rank 60 (page 2). New batch keeps them on page 2.
+    await db.insert(playerRank1v1).values([{ brawlhallaId: 991001, region: TEST_REGION, rank: 60 }])
+
+    const result = await playerRepo.replaceRankPage1v1({
+      region: TEST_REGION,
+      page: 2,
+      pageSize: 50,
+      entries: [{ brawlhallaId: 991001, rank: 75 }],
+    })
+
+    expect(result.vacatedSourcePages).toEqual([])
+  })
 })

--- a/packages/contexts/ranking/tests/sync-rankings.rank-2v2.test.ts
+++ b/packages/contexts/ranking/tests/sync-rankings.rank-2v2.test.ts
@@ -122,4 +122,116 @@ describe('replaceRankPage2v2', () => {
     expect(selfTeam.length).toBe(1)
     expect(selfTeam[0]?.brawlhallaId).toBe(992001)
   })
+
+  it('returns empty vacatedSourcePages when no batch team exists outside the page range', async () => {
+    const result = await playerRepo.replaceRankPage2v2({
+      region: TEST_REGION,
+      page: 1,
+      pageSize: 50,
+      teams: [
+        {
+          brawlhallaIdOne: TEST_IDS[0],
+          brawlhallaIdTwo: TEST_IDS[1],
+          teamName: 'A+B',
+          rating: 2000,
+          peakRating: 2000,
+          tier: 'Gold',
+          wins: 10,
+          games: 20,
+          globalRank: 1,
+        },
+      ],
+    })
+    expect(result.vacatedSourcePages).toEqual([])
+  })
+
+  it('returns distinct source pages for cross-page mover teams', async () => {
+    await db.delete(playerRankedTeam).where(eq(playerRankedTeam.region, TEST_REGION))
+    await db.insert(playerRankedTeam).values([
+      {
+        brawlhallaId: TEST_IDS[0],
+        brawlhallaIdOne: TEST_IDS[0],
+        brawlhallaIdTwo: TEST_IDS[1],
+        teamName: 'A+B',
+        rating: 1500,
+        peakRating: 1500,
+        tier: 'Gold',
+        wins: 1,
+        games: 2,
+        region: TEST_REGION,
+        globalRank: 60,
+      },
+      {
+        brawlhallaId: TEST_IDS[1],
+        brawlhallaIdOne: TEST_IDS[0],
+        brawlhallaIdTwo: TEST_IDS[1],
+        teamName: 'A+B',
+        rating: 1500,
+        peakRating: 1500,
+        tier: 'Gold',
+        wins: 1,
+        games: 2,
+        region: TEST_REGION,
+        globalRank: 60,
+      },
+      {
+        brawlhallaId: TEST_IDS[2],
+        brawlhallaIdOne: TEST_IDS[2],
+        brawlhallaIdTwo: TEST_IDS[3],
+        teamName: 'C+D',
+        rating: 1300,
+        peakRating: 1300,
+        tier: 'Silver',
+        wins: 1,
+        games: 2,
+        region: TEST_REGION,
+        globalRank: 105,
+      },
+      {
+        brawlhallaId: TEST_IDS[3],
+        brawlhallaIdOne: TEST_IDS[2],
+        brawlhallaIdTwo: TEST_IDS[3],
+        teamName: 'C+D',
+        rating: 1300,
+        peakRating: 1300,
+        tier: 'Silver',
+        wins: 1,
+        games: 2,
+        region: TEST_REGION,
+        globalRank: 105,
+      },
+    ])
+
+    const result = await playerRepo.replaceRankPage2v2({
+      region: TEST_REGION,
+      page: 4,
+      pageSize: 50,
+      teams: [
+        {
+          brawlhallaIdOne: TEST_IDS[0],
+          brawlhallaIdTwo: TEST_IDS[1],
+          teamName: 'A+B',
+          rating: 1700,
+          peakRating: 1700,
+          tier: 'Plat',
+          wins: 1,
+          games: 2,
+          globalRank: 151,
+        },
+        {
+          brawlhallaIdOne: TEST_IDS[2],
+          brawlhallaIdTwo: TEST_IDS[3],
+          teamName: 'C+D',
+          rating: 1700,
+          peakRating: 1700,
+          tier: 'Plat',
+          wins: 1,
+          games: 2,
+          globalRank: 152,
+        },
+      ],
+    })
+
+    expect(result.vacatedSourcePages.sort()).toEqual([2, 3])
+  })
 })

--- a/packages/contexts/ranking/tests/sync-rankings.test.ts
+++ b/packages/contexts/ranking/tests/sync-rankings.test.ts
@@ -172,6 +172,55 @@ describe('sync1v1Page', () => {
     const cursorScanAfter = await redis.keys('cursor:test:explicit:*')
     expect(cursorScanAfter.length).toBe(0)
   })
+
+  it('enqueues vacated source pages to resync set at depth=0', async () => {
+    const lockState: LockState = { lost: false, value: 'test-lock' }
+    const queueKey = 'resync:1v1:queue'
+    await redis.del(queueKey)
+
+    const deps = {
+      db: {} as never,
+      bhapi: makeFakeBhapi([{ ...SAMPLE, rank: 151 }]),
+      redis,
+      rankedQueue: {} as never,
+      statsQueue: {} as never,
+      clanQueue: {} as never,
+      metrics: NULL_METRICS,
+    }
+    const repo = makeFakeRepo()
+    ;(repo as unknown as { replaceRankPage1v1: () => Promise<{ vacatedSourcePages: number[] }> }).replaceRankPage1v1 =
+      async () => ({ vacatedSourcePages: [3, 5, 41, 1] }) // page 1 filtered (hot), 41 filtered (out of cap), 3+5 kept
+
+    await sync1v1Page(deps, repo, 'us-e', 4, 4, null, lockState, { depth: 0 })
+
+    const queued = await redis.smembers(queueKey)
+    await redis.del(queueKey)
+    expect(queued.sort()).toEqual(['US-E:3', 'US-E:5'])
+  })
+
+  it('does not enqueue at depth=1 even when source pages are vacated', async () => {
+    const lockState: LockState = { lost: false, value: 'test-lock' }
+    const queueKey = 'resync:1v1:queue'
+    await redis.del(queueKey)
+
+    const deps = {
+      db: {} as never,
+      bhapi: makeFakeBhapi([{ ...SAMPLE, rank: 151 }]),
+      redis,
+      rankedQueue: {} as never,
+      statsQueue: {} as never,
+      clanQueue: {} as never,
+      metrics: NULL_METRICS,
+    }
+    const repo = makeFakeRepo()
+    ;(repo as unknown as { replaceRankPage1v1: () => Promise<{ vacatedSourcePages: number[] }> }).replaceRankPage1v1 =
+      async () => ({ vacatedSourcePages: [3, 5] })
+
+    await sync1v1Page(deps, repo, 'us-e', 4, 4, null, lockState, { depth: 1 })
+
+    const queued = await redis.smembers(queueKey)
+    expect(queued).toEqual([])
+  })
 })
 
 describe('renewLock heartbeat error handling', () => {

--- a/packages/contexts/ranking/tests/sync-rankings.test.ts
+++ b/packages/contexts/ranking/tests/sync-rankings.test.ts
@@ -148,6 +148,30 @@ describe('sync1v1Page', () => {
     const after = await redis.get(cursorKey)
     expect(after).toBe('5')
   })
+
+  it('with cursorKey=null syncs the explicit page and does not touch any cursor', async () => {
+    const lockState: LockState = { lost: false, value: 'test-lock' }
+    const cursorScanBefore = await redis.keys('cursor:test:explicit:*')
+    expect(cursorScanBefore.length).toBe(0)
+
+    const deps = {
+      db: {} as never,
+      bhapi: makeFakeBhapi([{ ...SAMPLE, rank: 75 }]),
+      redis,
+      rankedQueue: {} as never,
+      statsQueue: {} as never,
+      clanQueue: {} as never,
+      metrics: NULL_METRICS,
+    }
+    const repo = makeFakeRepo()
+    ;(repo as unknown as { replaceRankPage1v1: () => Promise<{ vacatedSourcePages: number[] }> }).replaceRankPage1v1 =
+      async () => ({ vacatedSourcePages: [] })
+
+    await sync1v1Page(deps, repo, 'us-e', 2, 2, null, lockState, { depth: 1 })
+
+    const cursorScanAfter = await redis.keys('cursor:test:explicit:*')
+    expect(cursorScanAfter.length).toBe(0)
+  })
 })
 
 describe('renewLock heartbeat error handling', () => {

--- a/packages/contexts/ranking/tests/sync-rankings.test.ts
+++ b/packages/contexts/ranking/tests/sync-rankings.test.ts
@@ -275,7 +275,8 @@ describe('drainResyncQueue', () => {
     expect(remaining).toEqual([])
     expect(calls.length).toBe(3)
     const sorted = calls.map((c) => `${c.region}:${c.page}`).sort()
-    expect(sorted).toEqual(['BRZ:9', 'EU:7', 'US-E:5'])
+    // Drain lowercases the region back to BHAPI form (queue stores uppercase via normalizeRegionKey).
+    expect(sorted).toEqual(['brz:9', 'eu:7', 'us-e:5'])
   })
 
   it('stops draining and re-adds remaining members when budget runs out mid-loop', async () => {

--- a/packages/contexts/ranking/tests/sync-rankings.test.ts
+++ b/packages/contexts/ranking/tests/sync-rankings.test.ts
@@ -1,9 +1,9 @@
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
-import type { BhApiClient, BhApiRanking1v1 } from '@brawltome/bhapi'
+import type { BhApiClient, BhApiRanking1v1, Region } from '@brawltome/bhapi'
 import type { PlayerRepo } from '@brawltome/player'
 import type { MetricsRegistry } from '@brawltome/shared'
 import Redis from 'ioredis'
-import { type LockState, sync1v1Page } from '../commands/sync-rankings'
+import { type LockState, drainResyncQueue, sync1v1Page } from '../commands/sync-rankings'
 
 let redis: Redis
 
@@ -236,6 +236,125 @@ describe('renewLock heartbeat error handling', () => {
 
     expect(lockState.lost).toBe(true)
     expect(calls).toContain('janitor:lock_lost_total')
+  })
+})
+
+describe('drainResyncQueue', () => {
+  it('drains all members within budget and processes each at depth=1', async () => {
+    const queueKey = 'resync:1v1:queue'
+    await redis.del(queueKey)
+    await redis.sadd(queueKey, 'US-E:5', 'EU:7', 'BRZ:9')
+
+    const calls: Array<{ region: string; page: number; depth: number }> = []
+    const deps = {
+      db: {} as never,
+      bhapi: {
+        remainingTokens: () => 1000,
+        async getRankings1v1(region: Region, page: number) {
+          calls.push({ region, page, depth: 1 })
+          return [{ ...SAMPLE, rank: page * 50 }]
+        },
+        async getRankings2v2() {
+          return []
+        },
+      } as unknown as BhApiClient,
+      redis,
+      rankedQueue: {} as never,
+      statsQueue: {} as never,
+      clanQueue: {} as never,
+      metrics: NULL_METRICS,
+    }
+    const repo = makeFakeRepo()
+    ;(repo as unknown as { replaceRankPage1v1: () => Promise<{ vacatedSourcePages: number[] }> }).replaceRankPage1v1 =
+      async () => ({ vacatedSourcePages: [] })
+
+    const lockState: LockState = { lost: false, value: 'test-lock' }
+    await drainResyncQueue(deps, repo, '1v1', lockState, performance.now())
+
+    const remaining = await redis.smembers(queueKey)
+    expect(remaining).toEqual([])
+    expect(calls.length).toBe(3)
+    const sorted = calls.map((c) => `${c.region}:${c.page}`).sort()
+    expect(sorted).toEqual(['BRZ:9', 'EU:7', 'US-E:5'])
+  })
+
+  it('stops draining and re-adds remaining members when budget runs out mid-loop', async () => {
+    const queueKey = 'resync:1v1:queue'
+    await redis.del(queueKey)
+    await redis.sadd(queueKey, 'US-E:5', 'EU:7', 'BRZ:9', 'AUS:11', 'JPN:13')
+
+    // Start at JANITOR_MIN_TOKENS (10) + 2 so exactly 3 syncs run before tokens drop below threshold.
+    let tokensLeft = 12
+    const deps = {
+      db: {} as never,
+      bhapi: {
+        remainingTokens: () => tokensLeft,
+        async getRankings1v1() {
+          tokensLeft--
+          return [{ ...SAMPLE }]
+        },
+        async getRankings2v2() {
+          return []
+        },
+      } as unknown as BhApiClient,
+      redis,
+      rankedQueue: {} as never,
+      statsQueue: {} as never,
+      clanQueue: {} as never,
+      metrics: NULL_METRICS,
+    }
+    const repo = makeFakeRepo()
+    ;(repo as unknown as { replaceRankPage1v1: () => Promise<{ vacatedSourcePages: number[] }> }).replaceRankPage1v1 =
+      async () => ({ vacatedSourcePages: [] })
+
+    const lockState: LockState = { lost: false, value: 'test-lock' }
+    await drainResyncQueue(deps, repo, '1v1', lockState, performance.now())
+
+    const remaining = await redis.smembers(queueKey)
+    await redis.del(queueKey)
+    // 3 syncs ran (tokens 12->11->10->9), leaving 2 in the queue
+    expect(remaining.length).toBe(2)
+  })
+
+  it('logs and counts errors but continues with remaining members', async () => {
+    const queueKey = 'resync:1v1:queue'
+    await redis.del(queueKey)
+    await redis.sadd(queueKey, 'US-E:5', 'EU:7')
+    const { metrics, calls } = makeSpyMetrics()
+
+    let firstCall = true
+    const deps = {
+      db: {} as never,
+      bhapi: {
+        remainingTokens: () => 1000,
+        async getRankings1v1() {
+          if (firstCall) {
+            firstCall = false
+            throw new Error('forced bhapi failure')
+          }
+          return [{ ...SAMPLE }]
+        },
+        async getRankings2v2() {
+          return []
+        },
+      } as unknown as BhApiClient,
+      redis,
+      rankedQueue: {} as never,
+      statsQueue: {} as never,
+      clanQueue: {} as never,
+      metrics,
+    }
+    const repo = makeFakeRepo()
+    ;(repo as unknown as { replaceRankPage1v1: () => Promise<{ vacatedSourcePages: number[] }> }).replaceRankPage1v1 =
+      async () => ({ vacatedSourcePages: [] })
+
+    const lockState: LockState = { lost: false, value: 'test-lock' }
+    await drainResyncQueue(deps, repo, '1v1', lockState, performance.now())
+
+    expect(calls).toContain('janitor:resync_failures')
+    const remaining = await redis.smembers(queueKey)
+    await redis.del(queueKey)
+    expect(remaining).toEqual([])
   })
 })
 

--- a/packages/database/drizzle/0010_rank_caps.sql
+++ b/packages/database/drizzle/0010_rank_caps.sql
@@ -1,0 +1,19 @@
+-- Drop rows beyond new cap (40 API pages × 50 = rank 2000)
+DELETE FROM "player_rank_1v1" WHERE "rank" > 2000;
+DELETE FROM "player_ranked_team" WHERE "global_rank" > 2000;
+--> statement-breakpoint
+
+-- Drop lowercase region rows (regional ghosts; 'all' stays lowercase)
+DELETE FROM "player_rank_1v1" WHERE "region" <> 'all' AND "region" <> upper("region");
+DELETE FROM "player_ranked_team" WHERE "region" <> 'all' AND "region" <> upper("region");
+--> statement-breakpoint
+
+-- CHECK constraints to prevent recurrence
+ALTER TABLE "player_rank_1v1"
+  ADD CONSTRAINT "player_rank_1v1_region_canonical"
+  CHECK ("region" = 'all' OR "region" = upper("region"));
+--> statement-breakpoint
+
+ALTER TABLE "player_ranked_team"
+  ADD CONSTRAINT "player_ranked_team_region_canonical"
+  CHECK ("region" = 'all' OR "region" = upper("region"));

--- a/packages/database/drizzle/0010_rank_caps.sql
+++ b/packages/database/drizzle/0010_rank_caps.sql
@@ -1,6 +1,9 @@
--- Drop rows beyond new cap (40 API pages × 50 = rank 2000)
+-- Drop rows beyond new cap (40 API pages × 50 = rank 2000) for the 1v1 rank-position table.
+-- player_ranked_team is intentionally NOT capped here: those rows hold team rating/games/wins
+-- data displayed on player profiles, not just leaderboard position. The janitor's
+-- MAX_COLD_PAGE = 40 already prevents new rows above rank 2000 from being inserted; existing
+-- low-rank team rows stay so profiles continue to render the player's full team list.
 DELETE FROM "player_rank_1v1" WHERE "rank" > 2000;
-DELETE FROM "player_ranked_team" WHERE "global_rank" > 2000;
 --> statement-breakpoint
 
 -- Drop lowercase region rows (regional ghosts; 'all' stays lowercase)

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1777324426317,
       "tag": "0009_material_prowler",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1746004800000,
+      "tag": "0010_rank_caps",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Plugs the page-2 row-loss leak introduced in `34ba3a5`, raises top-100-per-region freshness, caps the leaderboard depth at 2000 entries (40 API pages = 100 frontend pages), and adds a CHECK constraint preventing lowercase region values from sneaking back in.

Diagnostic against prod showed every region's API page 2 sits at 43-49/50 rows because cold-rotation page-3 syncs implicitly vacate page-2 rows for cross-page movers, and page 2 doesn't re-sync for ~5.5h. The expanded hot regional rotation (pages 1-2 instead of just page 1) plus a source-page resync queue eliminate the leak.

## What changed

**Cadence**
- `MAX_COLD_PAGE = 40` (was 200) — caps regional + 'all' rotations at API page 40 = 2000 entries
- `HOT_REGIONAL_PAGES = 2` (was 1) — each tick syncs pages 1 AND 2 of the rotated region
- Frontend `MAX_PAGE = 100` — pagination clamp matches the new data depth

**Correctness**
- `replaceRankPage1v1` / `replaceRankPage2v2` now return `{ vacatedSourcePages: number[] }` — distinct pages of existing rows in the same region whose ID is in the batch but rank is outside the new page's range
- `sync*Page` accepts `cursorKey: string | null` (null = explicit page, no cursor) and `opts: { depth: 0 | 1 }`
- At depth=0, `sync*Page` SADDs vacated source pages to `resync:{1v1|2v2}:queue` (filters out hot-zone pages and pages > MAX_COLD_PAGE)
- New `drainResyncQueue` runs at start of each janitor tick, greedily processes queue at depth=1 (no further enqueue), bounded by token availability + 30s wall-clock budget. Errors logged + counted as `janitor:resync_failures`
- Drain uses per-iteration `SPOP` so a process crash mid-loop only loses the in-flight entry, not the whole backlog (CodeRabbit feedback)
- Drain lowercases the region back to BHAPI form when constructing `getRankings*` calls (CodeRabbit feedback)

**Cleanup (migration `0010_rank_caps.sql`)**
- DELETE rows with `rank > 2000` from `player_rank_1v1` (rank-position table, no rating data)
- DELETE lowercase regional region rows from both tables (preserving 'all')
- ADD CHECK constraints `region = 'all' OR region = upper(region)` on both tables
- **Intentionally NOT capping `player_ranked_team` by `global_rank`**: those rows carry team rating/games/wins displayed on player profiles. The janitor's `MAX_COLD_PAGE = 40` already prevents new rows above rank 2000 from being inserted; existing low-rank rows stay so profiles render the player's full team history.

**Tooling**
- `apps/api/scripts/reset-rank-cursors.ts` — Redis cursor reset helper for deploy. Resets cold + cold-regional cursors only; hot 'all' and per-page hot regional cursors don't carry stale state.

## Spec & plan

`docs/plans/2026-04-28-ranking-accuracy-followup-design.md` (spec)
`docs/plans/2026-04-28-ranking-accuracy-followup-plan.md` (implementation plan)
`docs/runbooks/rank-cap-deploy.md` (deploy runbook — also inlined below)

## Test plan

- [x] `bun test` — 293 pass, 0 fail (7 pre-existing skips)
- [x] `bun run --filter '*' typecheck` — clean
- [x] `bunx biome check .` — clean
- [x] Post-deploy: re-run the diff script (DB top 100 per region vs Brawlhalla API top 100 per region). Pass criteria: 0 missing per page, 0 rating drift on shared top 100
- [x] Post-deploy: verify `/internal/metrics` `janitor:resync_failures` stays low (<5/24h)
- [x] Post-deploy: confirm `?page=150` clamps to 100 in browser
- [x] Post-deploy: spot-check a profile page for a player at 2v2 rank ~5000 to confirm their teams still render

## Pre-deploy baseline (captured 2026-04-28)

| Metric | Value | Migration impact |
|---|---|---|
| `player_rank_1v1` total | 53,297 | 33,545 rows deleted (rank > 2000) |
| `player_ranked_team` total | 113,382 | 0 rows deleted (intentionally not capped) |
| Lowercase 1v1 region rows | 50 | all deleted |
| Lowercase team region rows | 94 | all deleted |
| Page-2 row counts (regional) | 43-49 of 50 | self-heal under hot regional pages 1-2 within ~9 min |

## Deploy runbook (inline)

### Pre-deploy

1. Backup affected tables:
   ```bash
   pg_dump --table=player_rank_1v1 --table=player_ranked_team --table=player \
     "$PROD_DATABASE_URL" | gzip > "backups/pre-rank-cap-$(date -u +%Y%m%d-%H%M).sql.gz"
   gunzip -t backups/pre-rank-cap-*.sql.gz   # must exit 0
   ```

2. Capture pre-deploy row counts (already captured above; re-run if material time has passed).

### Deploy

3. Apply migration:
   ```bash
   DATABASE_URL="$PROD_DATABASE_URL" bun --cwd packages/database run migrate
   ```

4. Reset Redis cold cursors:
   ```bash
   REDIS_URL="$PROD_REDIS_URL" bun run apps/api/scripts/reset-rank-cursors.ts
   ```

5. Deploy new janitor code (api container) — restart picks up new constants and drain logic.

### Post-deploy verification

6. Wait ~90 minutes for hot regional rotation to cycle through all 9 regions ~10 times.

7. Run diff script against prod tunnel — expect 0 missing per page, 0 rating drift on shared top 100, ≤2 rank-position drift per region.

8. Check `/internal/metrics`:
   - `counters['janitor:resync_failures']` should be 0 or very low
   - `counters['janitor:tick_failures']` shouldn't increase faster than baseline
   - `bhapi.tokens_background_remaining` shouldn't pin to 0

### Rollback

If verification fails:
1. `gunzip -c backups/pre-rank-cap-YYYYMMDD-HHMM.sql.gz | psql "$PROD_DATABASE_URL"`
2. Revert deployment to prior commit
3. Drop CHECK constraints if applied:
   ```sql
   ALTER TABLE player_rank_1v1 DROP CONSTRAINT player_rank_1v1_region_canonical;
   ALTER TABLE player_ranked_team DROP CONSTRAINT player_ranked_team_region_canonical;
   ```