### PR TITLE
hotfix(ranking): cap drain at 3/tick + bail when bhapi is paused

### DIFF
--- a/packages/contexts/ranking/commands/sync-rankings.ts
+++ b/packages/contexts/ranking/commands/sync-rankings.ts
@@ -304,6 +304,7 @@ export async function sync2v2Page(
 }
 
 const TICK_BUDGET_MS = 30_000
+const MAX_DRAIN_PER_TICK = 3
 
 export async function drainResyncQueue(
   deps: JanitorDeps,
@@ -315,11 +316,18 @@ export async function drainResyncQueue(
   const queueKey = `resync:${bracket}:queue`
   // SPOP per iteration: each entry leaves the set only after we own it. A crash mid-loop
   // loses at most the in-flight entry, not the rest of the backlog. Budget guards (lock,
-  // tokens, wall clock) check FIRST so we don't pop entries we won't process.
+  // tokens, wall clock, BHAPI pause, per-tick cap) check FIRST so we don't pop entries we
+  // won't process.
+  let drained = 0
   while (true) {
     if (lockState.lost) break
     if (deps.bhapi.remainingTokens('background') < JANITOR_MIN_TOKENS) break
     if (performance.now() - tickStart > TICK_BUDGET_MS) break
+    // Don't queue up more 429s on top of an already-paused window.
+    if (deps.bhapi.pausedUntilMs > Date.now()) break
+    // Per-tick cap: leave background headroom for hot rotation + on-demand. Drain is best-effort
+    // catch-up; the cold cursor still covers everything within its cycle.
+    if (drained >= MAX_DRAIN_PER_TICK) break
 
     const member = await deps.redis.spop(queueKey)
     if (!member) break
@@ -331,6 +339,8 @@ export async function drainResyncQueue(
     const region = rawRegion === 'all' ? 'all' : (rawRegion.toLowerCase() as Region)
     const page = Number.parseInt(member.slice(sep + 1), 10)
     if (!Number.isFinite(page)) continue
+    // Count toward cap regardless of outcome — failed syncs still consumed a BHAPI call.
+    drained++
     try {
       if (bracket === '1v1') {
         await sync1v1Page(deps, playerRepo, region, page, page, null, lockState, { depth: 1 })

--- a/packages/contexts/ranking/tests/sync-rankings.test.ts
+++ b/packages/contexts/ranking/tests/sync-rankings.test.ts
@@ -357,6 +357,84 @@ describe('drainResyncQueue', () => {
     await redis.del(queueKey)
     expect(remaining).toEqual([])
   })
+
+  it('caps drain at MAX_DRAIN_PER_TICK regardless of remaining queue size', async () => {
+    const queueKey = 'resync:1v1:queue'
+    await redis.del(queueKey)
+    await redis.sadd(queueKey, 'US-E:5', 'EU:7', 'BRZ:9', 'AUS:11', 'JPN:13', 'SEA:15', 'ME:17')
+
+    const calls: string[] = []
+    const deps = {
+      db: {} as never,
+      bhapi: {
+        remainingTokens: () => 1000,
+        pausedUntilMs: 0,
+        async getRankings1v1(region: Region, page: number) {
+          calls.push(`${region}:${page}`)
+          return [{ ...SAMPLE }]
+        },
+        async getRankings2v2() {
+          return []
+        },
+      } as unknown as BhApiClient,
+      redis,
+      rankedQueue: {} as never,
+      statsQueue: {} as never,
+      clanQueue: {} as never,
+      metrics: NULL_METRICS,
+    }
+    const repo = makeFakeRepo()
+    ;(repo as unknown as { replaceRankPage1v1: () => Promise<{ vacatedSourcePages: number[] }> }).replaceRankPage1v1 =
+      async () => ({ vacatedSourcePages: [] })
+
+    const lockState: LockState = { lost: false, value: 'test-lock' }
+    await drainResyncQueue(deps, repo, '1v1', lockState, performance.now())
+
+    expect(calls.length).toBe(3)
+    const remaining = await redis.smembers(queueKey)
+    await redis.del(queueKey)
+    expect(remaining.length).toBe(4)
+  })
+
+  it('breaks immediately when bhapi is paused', async () => {
+    const queueKey = 'resync:1v1:queue'
+    await redis.del(queueKey)
+    await redis.sadd(queueKey, 'US-E:5', 'EU:7', 'BRZ:9')
+
+    const calls: string[] = []
+    const deps = {
+      db: {} as never,
+      bhapi: {
+        remainingTokens: () => 1000,
+        // Paused 5 seconds into the future — drain must not call BHAPI.
+        pausedUntilMs: Date.now() + 5_000,
+        async getRankings1v1(region: Region, page: number) {
+          calls.push(`${region}:${page}`)
+          return [{ ...SAMPLE }]
+        },
+        async getRankings2v2() {
+          return []
+        },
+      } as unknown as BhApiClient,
+      redis,
+      rankedQueue: {} as never,
+      statsQueue: {} as never,
+      clanQueue: {} as never,
+      metrics: NULL_METRICS,
+    }
+    const repo = makeFakeRepo()
+    ;(repo as unknown as { replaceRankPage1v1: () => Promise<{ vacatedSourcePages: number[] }> }).replaceRankPage1v1 =
+      async () => ({ vacatedSourcePages: [] })
+
+    const lockState: LockState = { lost: false, value: 'test-lock' }
+    await drainResyncQueue(deps, repo, '1v1', lockState, performance.now())
+
+    expect(calls.length).toBe(0)
+    const remaining = await redis.smembers(queueKey)
+    await redis.del(queueKey)
+    // All entries left intact since drain bailed before SPOP.
+    expect(remaining.length).toBe(3)
+  })
 })
 
 describe('lockState abort', () => {


### PR DESCRIPTION
## Summary

12h post-deploy metrics from PR #139 showed the resync drain stuck in a steady-state 429 storm:

| Metric | Right after deploy | Now (+12h) | Δ/hour |
|---|---|---|---|
| janitor:resync_failures | 4 | 324 | **+27/h** sustained |
| tokens_background_remaining | 9 | 9 | stuck low |
| refresh-ranked drained | +15/h pre-deploy | +8.5/h | **slower than baseline** |

Drain was greedily emptying the queue every tick, blowing past Brawlhalla's actual rate limit, getting 429'd, pausing, and starving the refresh-ranked / refresh-stats queues of tokens.

## Fix

Two guards in `drainResyncQueue`:

1. **`MAX_DRAIN_PER_TICK = 3`** — bounds per-tick BHAPI burst regardless of queue size. Drain is best-effort catch-up; the cold cursor still covers every page within its cycle, so capping drain just spreads the work across more ticks.
2. **Bail when `bhapi.pausedUntilMs > Date.now()`** — drain stops the moment BHAPI says wait, instead of plowing into another 429.

`drained++` moved before the try-catch so failed syncs still count toward the cap (a 429 still consumed a BHAPI call attempt).

## Test plan

- [x] 2 new unit tests: per-tick cap, pause-bail
- [x] All 12 existing drain tests pass
- [x] Typecheck clean
- [ ] Post-deploy: `janitor:resync_failures` rate drops below 5/h
- [ ] Post-deploy: `tokens_background_remaining` recovers above 30
- [ ] Post-deploy: `refresh-ranked drained` rate climbs back to ~15/h baseline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance & Stability**
  * Optimized ranking synchronization queue processing with improved capacity management and pause handling to enhance system reliability.

* **Tests**
  * Added comprehensive test coverage for ranking queue behavior under various conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->