### PR TITLE
fix: 3v3 winrate, 2v2 name protection, profile teammate names

### DIFF
--- a/apps/web/src/components/player/TeamSection.tsx
+++ b/apps/web/src/components/player/TeamSection.tsx
@@ -133,12 +133,19 @@ export function TeamSection({ player, rankedTeams, id }: TeamSectionProps) {
           const teammateHref = `/player/${teammateId}`
           const bannerUrl = getRankBanner(team.tier)
 
-          const teamNameParts = fixEncoding(team.teamName).split('+')
-          const teammateNameIndex = team.brawlhallaIdOne === Number.parseInt(id) ? 1 : 0
-          const teammateName =
-            teamNameParts[teammateNameIndex]?.trim() ||
-            teamNameParts.find((part: string) => part.trim() !== fixEncoding(player.name))?.trim() ||
-            fixEncoding(team.teamName)
+          // Prefer the enriched teammateName from the player table (set by getPlayer).
+          // Fall back to parsing the legacy teamName "PlayerOne+PlayerTwo" format for any
+          // pre-sweep rows that haven't been refreshed yet.
+          let teammateName = team.teammateName ? fixEncoding(team.teammateName) : ''
+          if (!teammateName && team.teamName) {
+            const teamNameParts = fixEncoding(team.teamName).split('+')
+            const teammateNameIndex = team.brawlhallaIdOne === idNumber ? 1 : 0
+            teammateName =
+              teamNameParts[teammateNameIndex]?.trim() ||
+              teamNameParts.find((part: string) => part.trim() !== fixEncoding(player.name))?.trim() ||
+              ''
+          }
+          if (!teammateName) teammateName = `Player ${teammateId}`
 
           return (
             <Link

--- a/packages/contexts/player/player.repo.ts
+++ b/packages/contexts/player/player.repo.ts
@@ -370,6 +370,9 @@ export function createPlayerRepo(db: Database) {
           tier: player.tier3v3,
           wins: player.wins3v3,
           losses: player.losses3v3,
+          // 3v3 has no stored `games` column — derive from wins+losses so the
+          // frontend's winrate calc has a non-zero denominator.
+          games: sql<number>`${player.wins3v3} + ${player.losses3v3}`.as('games'),
           rank: sql<number>`row_number() over (order by ${player.rating3v3} desc, ${player.wins3v3} desc)`.as('rank'),
         })
         .from(player)
@@ -655,16 +658,17 @@ export function createPlayerRepo(db: Database) {
       // Sort by PK so concurrent sweep workers acquire row locks in identical order,
       // avoiding postgres deadlocks on the player table.
       placeholders.sort((a, b) => a.brawlhallaId - b.brawlhallaId)
-      // Refresh existing player names too: a player who only appears in 2v2 sweeps would
-      // otherwise be stuck on whatever name the previous sweep wrote (or stale from 1v1 if
-      // they used to play 1v1). On conflict, replace name with the value just inserted.
+      // Only overwrite the player's name when the existing row is still a `Player {id}`
+      // placeholder. The 2v2 endpoint can return stale usernames (cached from team creation),
+      // so refreshing every name would clobber fresh names written by the 1v1 sweep or by
+      // /player/{id}/ranked enrichment.
       await db
         .insert(player)
         .values(placeholders as (typeof player.$inferInsert)[])
         .onConflictDoUpdate({
           target: player.brawlhallaId,
           set: {
-            name: sql`excluded.name`,
+            name: sql`CASE WHEN player.name = ('Player ' || player.brawlhalla_id::text) THEN excluded.name ELSE player.name END`,
           },
         })
 

--- a/packages/contexts/player/player.ts
+++ b/packages/contexts/player/player.ts
@@ -28,7 +28,7 @@ export type PlayerResult = InferSelectModel<typeof player> & {
   weaponStats: InferSelectModel<typeof playerWeaponStat>[]
   clan: InferSelectModel<typeof playerClan> | null
   rankedLegends: InferSelectModel<typeof playerRankedLegend>[]
-  rankedTeams: InferSelectModel<typeof playerRankedTeam>[]
+  rankedTeams: Array<InferSelectModel<typeof playerRankedTeam> & { teammateName: string | null }>
   ratingHistory: InferSelectModel<typeof ratingHistory>[]
   bestLegendNameKey: string | null
 }

--- a/packages/contexts/player/queries/get-player.ts
+++ b/packages/contexts/player/queries/get-player.ts
@@ -6,17 +6,34 @@ export async function getPlayer(repo: PlayerRepo, brawlhallaId: number): Promise
   const p = await repo.findById(brawlhallaId)
   if (!p) return null
 
-  const [history, effective] = await Promise.all([
+  // Collect teammate IDs (the OTHER side of each ranked-team row). Solo entries have
+  // brawlhallaIdTwo === 0, so the "teammate" is 0 — skip those.
+  const teammateIds = new Set<number>()
+  for (const t of p.rankedTeams) {
+    const other = t.brawlhallaIdOne === brawlhallaId ? t.brawlhallaIdTwo : t.brawlhallaIdOne
+    if (other > 0) teammateIds.add(other)
+  }
+
+  const [history, effective, teammateNames] = await Promise.all([
     repo.getRatingHistory(brawlhallaId),
     repo.getEffectiveBestLegend(brawlhallaId),
+    teammateIds.size > 0 ? repo.getPlayerNames([...teammateIds]) : Promise.resolve(new Map<number, string>()),
   ])
 
   const enrichedStatsLegends = (p.statsLegends || []).map((l) =>
     enrichStatsLegend(l, getLegendById, normalizeWeaponName),
   )
 
+  // Attach teammateName so the frontend doesn't have to derive it from teamName
+  // (the new sweep no longer populates teamName — endpoint doesn't return it).
+  const rankedTeams = p.rankedTeams.map((t) => {
+    const other = t.brawlhallaIdOne === brawlhallaId ? t.brawlhallaIdTwo : t.brawlhallaIdOne
+    return { ...t, teammateName: other > 0 ? (teammateNames.get(other) ?? null) : null }
+  })
+
   return {
     ...p,
+    rankedTeams,
     statsLegends: enrichedStatsLegends,
     ratingHistory: history,
     bestLegend: effective?.legendId ?? p.bestLegend ?? 0,

--- a/packages/contexts/ranking/tests/sweep-upserts.test.ts
+++ b/packages/contexts/ranking/tests/sweep-upserts.test.ts
@@ -150,22 +150,42 @@ describe('sweepUpsert2v2', () => {
     expect(byId.get(9_900_021)).toBe('BetaName')
   })
 
-  it('refreshes name on conflict for an existing 2v2-only player', async () => {
+  it('does not overwrite a real name on conflict (only refreshes placeholders)', async () => {
+    // Seed an existing player with a real name (as if 1v1 sweep wrote it).
+    await db.insert(player).values({ brawlhallaId: 9_900_020, name: 'RealAlpha' }).onConflictDoNothing()
+    await db.insert(player).values({ brawlhallaId: 9_900_021, name: 'RealBeta' }).onConflictDoNothing()
+
+    // 2v2 sweep arrives with potentially-stale usernames from the team endpoint.
     await repo.sweepUpsert2v2([
       {
         brawlhallaIdOne: 9_900_020,
         brawlhallaIdTwo: 9_900_021,
-        playerOneName: 'OldAlpha',
-        playerTwoName: 'OldBeta',
+        playerOneName: 'StaleAlpha',
+        playerTwoName: 'StaleBeta',
         teamName: 'team',
-        rating: 1800,
-        peakRating: 1850,
+        rating: 1900,
+        peakRating: 1900,
         tier: 'Diamond',
-        wins: 40,
+        wins: 50,
         losses: 20,
         region: 'EU',
       },
     ])
+    const owners = await db
+      .select()
+      .from(player)
+      .where(inArray(player.brawlhallaId, [9_900_020, 9_900_021]))
+    const byId = new Map(owners.map((p) => [p.brawlhallaId, p.name]))
+    // Real names preserved, NOT overwritten by stale 2v2 usernames.
+    expect(byId.get(9_900_020)).toBe('RealAlpha')
+    expect(byId.get(9_900_021)).toBe('RealBeta')
+  })
+
+  it('refreshes name when the existing row is still a Player {id} placeholder', async () => {
+    // Seed the placeholder format that 2v2-only players would have.
+    await db.insert(player).values({ brawlhallaId: 9_900_020, name: 'Player 9900020' }).onConflictDoNothing()
+    await db.insert(player).values({ brawlhallaId: 9_900_021, name: 'Player 9900021' }).onConflictDoNothing()
+
     await repo.sweepUpsert2v2([
       {
         brawlhallaIdOne: 9_900_020,


### PR DESCRIPTION
## Summary

Three production hotfixes after #141 landed.

### 3v3 leaderboard showed 0 games / 0% win rate
`get3v3LeaderboardSweep` returned `wins` but no `games` field, so the frontend's win-rate calc divided by 0. Fix: derive `games = wins_3v3 + losses_3v3` in the SELECT.

### Profile pages showed "Teammate ID: ..." instead of teammate names
`TeamSection.tsx` derived the teammate name by splitting the legacy `team.teamName` "PlayerOne+PlayerTwo" string on `+`. The new sweep doesn't populate `teamName` (the new endpoint doesn't return it), so the parsed name was empty and only the raw ID rendered. Fix: `getPlayer` now batch-looks-up teammate names from the `player` table and attaches `teammateName` to each rankedTeam row; `TeamSection` reads that field directly. Falls back to legacy parsing for any pre-sweep rows that haven't been refreshed yet.

### 2v2 sweep no longer stomps real names (defensive)
The 2v2 endpoint can return stale usernames in `players[].username`. The previous behavior `onConflictDoUpdate { name: excluded.name }` would clobber fresh names written by the 1v1 sweep. Fix: only refresh `player.name` when the existing row is still a `Player {id}` placeholder.

## Test plan

- [x] `sweepUpsert2v2 > does not overwrite a real name on conflict` — seed real name, run 2v2 sweep with stale name, real name persists
- [x] `sweepUpsert2v2 > refreshes name when the existing row is still a Player {id} placeholder`
- [x] All ranking + player tests pass (44/44)
- [x] Typecheck clean across all 15 packages
- [x] Verify on prod: 3v3 leaderboard shows non-zero win rate
- [x] Verify on prod: profile pages show real teammate names instead of "Teammate ID: ..."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Improved teammate name display to prioritize enriched sources, falling back to "Player {ID}" when unavailable
  * Prevented accidental overwriting of valid player names with stale data during synchronization
  * Fixed winrate calculation denominator to properly account for all games played

<!-- end of auto-generated comment: release notes by coderabbit.ai -->