### PR TITLE
fix: detection offset drift, API hostname, and 2s opponent refetch

### DIFF
--- a/apps/desktop/app/src/api_client.rs
+++ b/apps/desktop/app/src/api_client.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
-const DEFAULT_API_BASE: &str = "https://brawltome.app";
+const DEFAULT_API_BASE: &str = "https://api.brawltome.app";
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/apps/desktop/app/src/main.rs
+++ b/apps/desktop/app/src/main.rs
@@ -250,7 +250,13 @@ fn main() {
                         }
                     };
 
+                    /// Delay before refetching opponent data after a match starts.
+                    /// Gives the BrawlTome backend a moment to ingest fresh data
+                    /// from the prior match before we re-query.
+                    const REFETCH_DELAY: std::time::Duration = std::time::Duration::from_secs(2);
+
                     let mut opponent_cache: HashMap<u32, api_client::OpponentData> = HashMap::new();
+                    let mut pending_refetch: Option<tokio::task::JoinHandle<()>> = None;
 
                     while let Some(event) = event_rx.recv().await {
                         match event {
@@ -258,11 +264,19 @@ fn main() {
                                 let _ = app_handle.emit("game-event", &LegacyScanning { event: "scanning" });
                             }
                             GameEvent::MatchEnded(p) => {
+                                if let Some(h) = pending_refetch.take() {
+                                    h.abort();
+                                }
                                 opponent_cache.clear();
                                 let _ = app_handle.emit("game-event", &LegacyMatchEnded { event: "match_ended" });
                                 let _ = p; // local_player_bhid currently unused on the React side
                             }
                             GameEvent::MatchStarted(p) => {
+                                // Cancel any pending refetch from a previous MatchStarted.
+                                if let Some(h) = pending_refetch.take() {
+                                    h.abort();
+                                }
+
                                 // Fetch opponent data for any BhIDs not already cached.
                                 let new_bhids: Vec<u32> = p.opponent_bhids.iter()
                                     .filter(|bhid| !opponent_cache.contains_key(bhid))
@@ -288,13 +302,14 @@ fn main() {
                                     .filter_map(|bhid| opponent_cache.get(bhid).cloned())
                                     .collect();
 
+                                let is_ranked = matches!(
+                                    p.match_type,
+                                    brawltome_events::MatchType::Ranked1v1
+                                        | brawltome_events::MatchType::Ranked2v2
+                                        | brawltome_events::MatchType::Ranked3v3
+                                );
+
                                 if !opponents.is_empty() {
-                                    let is_ranked = matches!(
-                                        p.match_type,
-                                        brawltome_events::MatchType::Ranked1v1
-                                            | brawltome_events::MatchType::Ranked2v2
-                                            | brawltome_events::MatchType::Ranked3v3
-                                    );
                                     let _ = app_handle.emit("game-event", &LegacyMatchFound {
                                         event: "match_found",
                                         opponents,
@@ -302,6 +317,47 @@ fn main() {
                                         local_player_id: p.local_player_bhid,
                                     });
                                 }
+
+                                // Schedule a refetch to pick up backend updates that arrived
+                                // after the initial fetch (e.g., the player's just-finished
+                                // prior match's stats taking a moment to ingest).
+                                let api_for_refetch = api.clone();
+                                let app_handle_for_refetch = app_handle.clone();
+                                let opponent_bhids = p.opponent_bhids.clone();
+                                let local_player_bhid = p.local_player_bhid;
+                                pending_refetch = Some(tokio::spawn(async move {
+                                    tokio::time::sleep(REFETCH_DELAY).await;
+
+                                    let mut fresh: HashMap<u32, api_client::OpponentData> = HashMap::new();
+                                    let mut fetches = Vec::new();
+                                    for bhid in &opponent_bhids {
+                                        let api = api_for_refetch.clone();
+                                        let bhid = *bhid;
+                                        fetches.push(tokio::spawn(async move {
+                                            (bhid, api.fetch_opponent(bhid).await)
+                                        }));
+                                    }
+                                    for task in fetches {
+                                        match task.await {
+                                            Ok((bhid, Ok(data))) => { fresh.insert(bhid, data); }
+                                            Ok((bhid, Err(e))) => log::warn!("Refetch failed for bhid {bhid}: {e}"),
+                                            Err(e) => log::warn!("Refetch task panicked: {e}"),
+                                        }
+                                    }
+
+                                    let opponents: Vec<api_client::OpponentData> = opponent_bhids.iter()
+                                        .filter_map(|bhid| fresh.get(bhid).cloned())
+                                        .collect();
+
+                                    if !opponents.is_empty() {
+                                        let _ = app_handle_for_refetch.emit("game-event", &LegacyMatchFound {
+                                            event: "match_found",
+                                            opponents,
+                                            is_ranked,
+                                            local_player_id: local_player_bhid,
+                                        });
+                                    }
+                                }));
                             }
                             GameEvent::OffsetsBroken(_) => {
                                 // Not yet wired to React; logged for now.

--- a/apps/desktop/app/src/main.rs
+++ b/apps/desktop/app/src/main.rs
@@ -225,7 +225,7 @@ fn main() {
                 let app_handle = app.handle().clone();
                 let api_url = std::env::var("BRAWLTOME_API_URL")
                     .map(|s| s.trim().to_string())
-                    .unwrap_or_else(|_| "https://brawltome.app".into());
+                    .unwrap_or_else(|_| "https://api.brawltome.app".into());
 
                 tauri::async_runtime::spawn(async move {
                     use std::collections::HashMap;


### PR DESCRIPTION
## Summary

Three coupled fixes that together restore desktop overlay functionality after the architecture split landed in PR #143.

## Changes

### 1. Detection offset drift fix (private submodule bump)
Brawlhalla added a u64-sized field somewhere in the player struct, shifting the connection-state field by 8 bytes. After the refactor exposed the issue (the original detection bug existed pre-refactor too but went unnoticed), the offset was empirically rediscovered:

- ` BHID_04C_OFFSET`: 252 -> 260
- Verified live: value 8 (CS_MENU) appears at offset 260 of the correct candidate; no other BhID match in the scan window has any known state value at any offset
- The private detection crate also gains a ` diagnose_04c_offsets` fallback that fires only when ` find_04c_addr` returns ` None`, dumping every u32 matching ` VALID_STATES` in the first 512 bytes after each BhID candidate. Saves an investigation round-trip the next time the offset shifts.

Submodule: ` 87d5c1f` -> ` 317b704`.

### 2. API hostname fix
Default API base was ` https://brawltome.app` but the actual backend lives at ` https://api.brawltome.app`. Updated in two places (` api_client.rs` constant + ` main.rs` env-var fallback). ` BRAWLTOME_API_URL` env var still overrides.

### 3. Opponent stats refetch (2s after MatchStarted)
The pre-refactor detection code had a ` REFETCH_DELAY = 2s` that re-queried the API after match start to handle backend ingest lag (player's just-finished prior match's stats taking a moment to settle). That behavior was tied to detection internals (` refetch_at` + ` refetch_and_emit`) and got dropped in the channel-based refactor.

This restores it at the correct architectural layer: the app crate, where enrichment lives. Implementation:
- After initial MatchStarted fetch+emit, spawn a refetch task that sleeps 2s then re-fetches and re-emits
- Refetch is cancelled if ` MatchEnded` arrives before the timer fires (no stale UI updates after match ends)
- Refetch is cancelled and replaced if a new ` MatchStarted` preempts it (back-to-back matches don't pile up tasks)

## Test plan

- [x] App attaches to Brawlhalla, finds local BhID, finds connection-state address (smoking-gun log: `Found connection state address`)
- [x] State transitions detected correctly: Menu, Character select, Match detected, Tracking, Paused
- [x] Overlay populates with opponent data on match start (no more 404s)
- [x] Overlay auto-refreshes with fresh stats ~2s after match start
- [x] Overlay clears on match end
- [x] Refetch correctly cancelled by quick MatchEnded (verified inline; no stale events leak)