### PR TITLE
feat(release): unsigned closed-beta release flow + silent auto-update

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,0 +1,100 @@
+name: Desktop Release
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  build:
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Set up SSH agent for private detection submodule
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.DETECTION_DEPLOY_KEY }}
+
+      - name: Add github.com to known hosts
+        shell: bash
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Initialize submodules with SSH agent
+        shell: bash
+        run: git submodule update --init --recursive
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/desktop
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install JS deps
+        run: bun install --frozen-lockfile
+
+      - name: Build Tauri release bundle
+        working-directory: apps/desktop
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: bun run --filter @brawltome/desktop tauri build
+
+      - name: Locate built artifacts
+        id: artifacts
+        shell: pwsh
+        run: |
+          $version = "${{ github.ref_name }}".TrimStart('v')
+          $bundleDir = "apps/desktop/app/target/release/bundle/nsis"
+          $exe = Get-ChildItem -Path $bundleDir -Filter "*-setup.exe" | Select-Object -First 1
+          $sig = Get-ChildItem -Path $bundleDir -Filter "*-setup.exe.sig" | Select-Object -First 1
+          if (-not $exe) { Write-Error "No installer .exe found in $bundleDir"; exit 1 }
+          if (-not $sig) { Write-Error "No installer .sig found in $bundleDir"; exit 1 }
+          echo "version=$version" >> $env:GITHUB_OUTPUT
+          echo "exe_path=$($exe.FullName)" >> $env:GITHUB_OUTPUT
+          echo "sig_path=$($sig.FullName)" >> $env:GITHUB_OUTPUT
+
+      - name: Rename installer to stable filename
+        shell: pwsh
+        run: |
+          Copy-Item "${{ steps.artifacts.outputs.exe_path }}" "apps/desktop/BrawlTome-Setup.exe"
+          Copy-Item "${{ steps.artifacts.outputs.sig_path }}" "apps/desktop/BrawlTome-Setup.exe.sig"
+
+      - name: Generate latest.json
+        shell: pwsh
+        run: |
+          $version = "${{ steps.artifacts.outputs.version }}"
+          $sig = (Get-Content "apps/desktop/BrawlTome-Setup.exe.sig" -Raw).Trim()
+          $url = "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/BrawlTome-Setup.exe"
+          $pubDate = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+          $latest = @{
+              version = $version
+              notes = "BrawlTome ${{ github.ref_name }}"
+              pub_date = $pubDate
+              platforms = @{
+                  "windows-x86_64" = @{
+                      signature = $sig
+                      url = $url
+                  }
+              }
+          }
+          $latest | ConvertTo-Json -Depth 5 | Set-Content -Path "apps/desktop/latest.json" -Encoding utf8
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            apps/desktop/BrawlTome-Setup.exe
+            apps/desktop/BrawlTome-Setup.exe.sig
+            apps/desktop/latest.json
+          generate_release_notes: true
+          fail_on_unmatched_files: true

--- a/apps/desktop/Cargo.lock
+++ b/apps/desktop/Cargo.lock
@@ -42,6 +42,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,6 +102,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "atk"
@@ -206,6 +221,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-shell",
+ "tauri-plugin-updater",
  "tokio",
  "windows-sys 0.59.0",
 ]
@@ -215,6 +231,7 @@ name = "brawltome-detection"
 version = "0.1.0"
 dependencies = [
  "brawltome-events",
+ "criterion",
  "log",
  "memchr",
  "serde",
@@ -354,6 +371,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,6 +430,58 @@ dependencies = [
  "serde",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
@@ -503,6 +578,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,10 +623,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -619,6 +755,17 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -786,6 +933,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,6 +1040,17 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -1358,6 +1522,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,6 +1564,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1742,6 +1923,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is-wsl"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1756,6 +1948,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1824,6 +2025,36 @@ dependencies = [
  "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1960,7 +2191,10 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags 2.11.1",
  "libc",
+ "plain",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2021,6 +2255,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2281,6 +2521,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2294,6 +2535,18 @@ dependencies = [
  "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2364,6 +2617,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "open"
@@ -2438,6 +2697,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2480,7 +2753,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -2605,6 +2878,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "plist"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2615,6 +2894,34 @@ dependencies = [
  "quick-xml",
  "serde",
  "time",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -2809,10 +3116,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -2931,15 +3267,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3000,10 +3341,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -3014,6 +3368,33 @@ checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3400,6 +3781,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3442,7 +3839,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -3621,7 +4018,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -3655,6 +4052,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3678,7 +4086,7 @@ dependencies = [
  "heck 0.5.0",
  "http",
  "image",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -3812,6 +4220,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.3",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3821,7 +4262,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -3844,7 +4285,7 @@ checksum = "2cadb13dad0c681e1e0a2c49ae488f0e2906ded3d57e7a0017f4aaf46e387117"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -4016,6 +4457,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4024,9 +4475,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -4670,6 +5119,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5302,7 +5760,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",
@@ -5350,6 +5808,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5370,6 +5838,26 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5430,6 +5918,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/apps/desktop/app/Cargo.toml
+++ b/apps/desktop/app/Cargo.toml
@@ -16,6 +16,7 @@ brawltome-events.workspace = true
 brawltome-detection.workspace = true
 tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-shell = "2"
+tauri-plugin-updater = "2"
 serde.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "sync", "macros", "time"] }

--- a/apps/desktop/app/src/lib.rs
+++ b/apps/desktop/app/src/lib.rs
@@ -14,6 +14,7 @@ pub fn run() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .invoke_handler(tauri::generate_handler![
             overlay::set_clickthrough,
             overlay::update_content_bounds,
@@ -28,6 +29,36 @@ pub fn run() {
             tray::install(app.handle())?;
 
             detection_bridge::spawn(app.handle());
+
+            // Background update check on startup. Silent: download + queue install
+            // for next launch. Skipped in dev builds so cargo run doesn't try to
+            // update itself.
+            #[cfg(not(debug_assertions))]
+            {
+                use tauri_plugin_updater::UpdaterExt;
+                let app_handle = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    match app_handle.updater() {
+                        Ok(updater) => match updater.check().await {
+                            Ok(Some(update)) => {
+                                log::info!(
+                                    "Update available: {} -> {}",
+                                    update.current_version,
+                                    update.version
+                                );
+                                if let Err(e) = update.download_and_install(|_, _| {}, || {}).await {
+                                    log::warn!("Update install failed: {e}");
+                                } else {
+                                    log::info!("Update queued; will apply on next launch");
+                                }
+                            }
+                            Ok(None) => log::debug!("No update available"),
+                            Err(e) => log::warn!("Update check failed: {e}"),
+                        },
+                        Err(e) => log::warn!("Updater not available: {e}"),
+                    }
+                });
+            }
 
             Ok(())
         })

--- a/apps/desktop/app/src/lib.rs
+++ b/apps/desktop/app/src/lib.rs
@@ -30,32 +30,41 @@ pub fn run() {
 
             detection_bridge::spawn(app.handle());
 
-            // Background update check on startup. Silent: download + queue install
-            // for next launch. Skipped in dev builds so cargo run doesn't try to
-            // update itself.
+            // Background update check on startup. Silent: download + install
+            // without UI. On Windows, Tauri exits the app to let the installer
+            // replace the running binary; on_before_exit logs the imminent quit
+            // so it isn't mysterious in beta-tester logs. Skipped in dev builds.
             #[cfg(not(debug_assertions))]
             {
                 use tauri_plugin_updater::UpdaterExt;
                 let app_handle = app.handle().clone();
                 tauri::async_runtime::spawn(async move {
-                    match app_handle.updater() {
-                        Ok(updater) => match updater.check().await {
-                            Ok(Some(update)) => {
-                                log::info!(
-                                    "Update available: {} -> {}",
-                                    update.current_version,
-                                    update.version
-                                );
-                                if let Err(e) = update.download_and_install(|_, _| {}, || {}).await {
-                                    log::warn!("Update install failed: {e}");
-                                } else {
-                                    log::info!("Update queued; will apply on next launch");
-                                }
+                    let updater = match app_handle
+                        .updater_builder()
+                        .on_before_exit(|| {
+                            log::info!("Update downloaded; app is about to quit so the installer can replace the running binary");
+                        })
+                        .build()
+                    {
+                        Ok(u) => u,
+                        Err(e) => {
+                            log::warn!("Updater not available: {e}");
+                            return;
+                        }
+                    };
+                    match updater.check().await {
+                        Ok(Some(update)) => {
+                            log::info!(
+                                "Update available: {} -> {}. App will quit and silently install when download completes.",
+                                update.current_version,
+                                update.version
+                            );
+                            if let Err(e) = update.download_and_install(|_, _| {}, || {}).await {
+                                log::warn!("Update install failed: {e}");
                             }
-                            Ok(None) => log::debug!("No update available"),
-                            Err(e) => log::warn!("Update check failed: {e}"),
-                        },
-                        Err(e) => log::warn!("Updater not available: {e}"),
+                        }
+                        Ok(None) => log::debug!("No update available"),
+                        Err(e) => log::warn!("Update check failed: {e}"),
                     }
                 });
             }

--- a/apps/desktop/app/tauri.conf.json
+++ b/apps/desktop/app/tauri.conf.json
@@ -39,12 +39,10 @@
   },
   "plugins": {
     "updater": {
-      "endpoints": [
-        "https://github.com/NickTacke/brawltome/releases/latest/download/latest.json"
-      ],
+      "endpoints": ["https://github.com/NickTacke/brawltome/releases/latest/download/latest.json"],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IERCRTNBNDExMDIzRDFFMkEKUldRcUhqMENFYVRqMjkvVS9lVmhSbWRUeENVT2l3dUZ6TFVVc01iNmh1c002dDZBeDIwdGJuYzAK",
       "windows": {
-        "installMode": "passive"
+        "installMode": "quiet"
       }
     }
   }

--- a/apps/desktop/app/tauri.conf.json
+++ b/apps/desktop/app/tauri.conf.json
@@ -27,7 +27,25 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
-    "icon": ["icons/icon.png"]
+    "targets": ["nsis"],
+    "icon": ["icons/icon.png"],
+    "windows": {
+      "nsis": {
+        "installMode": "currentUser",
+        "languages": ["English"]
+      }
+    },
+    "createUpdaterArtifacts": true
+  },
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://github.com/NickTacke/brawltome/releases/latest/download/latest.json"
+      ],
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IERCRTNBNDExMDIzRDFFMkEKUldRcUhqMENFYVRqMjkvVS9lVmhSbWRUeENVT2l3dUZ6TFVVc01iNmh1c002dDZBeDIwdGJuYzAK",
+      "windows": {
+        "installMode": "passive"
+      }
+    }
   }
 }

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -1,0 +1,75 @@
+# scripts/release.ps1
+#
+# Bumps the desktop app version in apps/desktop/Cargo.toml + apps/desktop/app/tauri.conf.json,
+# commits the change, and creates a v$VERSION tag locally.
+# Manual `git push origin master --tags` is intentional - gives a chance to inspect
+# before triggering CI.
+#
+# Usage: ./scripts/release.ps1 0.1.0
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$Version
+)
+
+$ErrorActionPreference = "Stop"
+
+# Strip leading 'v' if user typed v0.1.0
+$Version = $Version.TrimStart('v')
+
+# Validate semver-ish (X.Y.Z, optionally with -suffix)
+if ($Version -notmatch '^\d+\.\d+\.\d+(-[\w\.]+)?$') {
+    Write-Error "Version '$Version' is not in X.Y.Z[-suffix] form"
+    exit 1
+}
+
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$CargoToml = Join-Path $RepoRoot "apps/desktop/Cargo.toml"
+$TauriConf = Join-Path $RepoRoot "apps/desktop/app/tauri.conf.json"
+
+if (-not (Test-Path $CargoToml)) {
+    Write-Error "Could not find $CargoToml"
+    exit 1
+}
+if (-not (Test-Path $TauriConf)) {
+    Write-Error "Could not find $TauriConf"
+    exit 1
+}
+
+# Update Cargo.toml [workspace.package] version
+# The line we want is `version = "X.Y.Z"` under [workspace.package].
+# That is the only `^version = "..."$` line in the file (other crates use version.workspace = true).
+$cargoContent = Get-Content $CargoToml -Raw
+if (-not ($cargoContent -match '(?m)^version = "[^"]*"$')) {
+    Write-Error "Could not find a 'version = \"...\"' line to replace in $CargoToml"
+    exit 1
+}
+$cargoUpdated = $cargoContent -replace '(?m)^version = "[^"]*"$', "version = `"$Version`""
+Set-Content -Path $CargoToml -Value $cargoUpdated -NoNewline
+
+# Update tauri.conf.json "version"
+$confJson = Get-Content $TauriConf -Raw | ConvertFrom-Json
+$confJson.version = $Version
+# ConvertTo-Json with -Depth 20 to handle nested plugins.updater config
+$confJson | ConvertTo-Json -Depth 20 | Set-Content $TauriConf
+
+Write-Host "Bumped version to $Version in:" -ForegroundColor Green
+Write-Host "  - $CargoToml"
+Write-Host "  - $TauriConf"
+
+# Stage; commit only if there's actually a diff (handles the case where the
+# version is already what we want, e.g., cutting v0.1.0 when both files
+# already say 0.1.0). Tag points at HEAD either way.
+git add $CargoToml $TauriConf
+$staged = git diff --cached --name-only
+if ($staged) {
+    git commit -m "chore(release): v$Version"
+} else {
+    Write-Host "No file changes (version was already $Version). Tagging current HEAD." -ForegroundColor Yellow
+}
+git tag "v$Version"
+
+Write-Host ""
+Write-Host "Tagged v$Version locally." -ForegroundColor Green
+Write-Host "To trigger the release CI workflow, run:"
+Write-Host "  git push origin master --tags" -ForegroundColor Cyan

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -45,7 +45,7 @@ if (-not ($cargoContent -match '(?m)^version = "[^"]*"$')) {
     exit 1
 }
 $cargoUpdated = $cargoContent -replace '(?m)^version = "[^"]*"$', "version = `"$Version`""
-Set-Content -Path $CargoToml -Value $cargoUpdated -NoNewline
+Set-Content -Path $CargoToml -Value $cargoUpdated -NoNewline -Encoding utf8
 
 # Update tauri.conf.json "version" via targeted regex (NOT ConvertTo-Json,
 # which reformats indentation + reorders properties + corrupts the file).

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -47,11 +47,17 @@ if (-not ($cargoContent -match '(?m)^version = "[^"]*"$')) {
 $cargoUpdated = $cargoContent -replace '(?m)^version = "[^"]*"$', "version = `"$Version`""
 Set-Content -Path $CargoToml -Value $cargoUpdated -NoNewline
 
-# Update tauri.conf.json "version"
-$confJson = Get-Content $TauriConf -Raw | ConvertFrom-Json
-$confJson.version = $Version
-# ConvertTo-Json with -Depth 20 to handle nested plugins.updater config
-$confJson | ConvertTo-Json -Depth 20 | Set-Content $TauriConf
+# Update tauri.conf.json "version" via targeted regex (NOT ConvertTo-Json,
+# which reformats indentation + reorders properties + corrupts the file).
+# -Encoding utf8 explicitly so Windows PowerShell 5.1 doesn't write a different
+# default encoding.
+$confContent = Get-Content $TauriConf -Raw
+if (-not ($confContent -match '"version"\s*:\s*"[^"]*"')) {
+    Write-Error "Could not find a '\"version\": \"...\"' line to replace in $TauriConf"
+    exit 1
+}
+$confUpdated = $confContent -replace '("version"\s*:\s*)"[^"]*"', "`$1`"$Version`""
+Set-Content -Path $TauriConf -Value $confUpdated -NoNewline -Encoding utf8
 
 Write-Host "Bumped version to $Version in:" -ForegroundColor Green
 Write-Host "  - $CargoToml"


### PR DESCRIPTION
## Summary

Adds the release pipeline that turns the desktop app into an installable + silently-self-updating product for closed beta. No code-signing (deferred); Tauri's Ed25519 updater handles auto-update integrity.

## What this lands

### Bundle config
- `tauri.conf.json bundle.targets`: `"all"` -> `["nsis"]` (Windows-only target; drops bundle work on irrelevant targets)
- `bundle.windows.nsis.installMode`: `currentUser` (no UAC; installs to `%LOCALAPPDATA%`)
- `bundle.createUpdaterArtifacts: true` (emits `.sig` next to the `.exe`)

### Auto-update plumbing
- `tauri-plugin-updater = "2"` Cargo dep
- `tauri.conf.json plugins.updater`: GitHub Releases `latest.json` endpoint, embedded Ed25519 public key, `passive` Windows install mode
- `lib.rs setup` callback: `cfg(not(debug_assertions))` startup task that checks + downloads + queues install silently

### Release pipeline
- `scripts/release.ps1`: atomic version bump (Cargo + tauri.conf.json) + commit + tag (handles no-change case for first v0.1.0 release)
- `.github/workflows/desktop-release.yml`: triggers on `v*` tag push, builds release bundle on `windows-latest`, generates `latest.json`, uploads installer + sig + manifest as GitHub Release assets

## What it does NOT include

- Code-signing (Microsoft Trusted Signing or EV cert) — deferred until demand validates
- Public download page — closed beta uses the GitHub stable URL directly
- Beta vs stable channel split — single channel for now
- In-app update notifications — fully silent
- `docs/RELEASE.md` runbook — kept local (per repo's no-commit-docs preference)

## Test plan

- [x] `cargo build` and `cargo build --release` both succeed locally
- [x] App launches and behaves as before in dev mode (updater check is gated out)
- [ ] Desktop CI passes
- [ ] After merge: cut v0.1.0 via the runbook, watch CI build + upload
- [ ] After release: download installer from the stable URL, install, confirm app launches
- [ ] After release: bump to v0.1.1, push tag, confirm installed app picks up the update on next launch

## Operational note

The `TAURI_SIGNING_PRIVATE_KEY` GitHub secret is already configured (one-time setup outside this PR). The companion `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` is intentionally not set; GitHub Actions evaluates a missing secret to an empty string, which Tauri's signer treats as "no passphrase" — exactly what we want.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Desktop application now automatically checks for updates on startup and seamlessly installs new versions when available.

* **Chores**
  * Implemented automated Windows desktop release workflow to streamline the build and distribution process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->