### PR TITLE
fix(release): make scripts/release.ps1 actually work on Windows PowerShell 5.1

### DIFF
--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -36,28 +36,39 @@ if (-not (Test-Path $TauriConf)) {
     exit 1
 }
 
-# Update Cargo.toml [workspace.package] version
-# The line we want is `version = "X.Y.Z"` under [workspace.package].
-# That is the only `^version = "..."$` line in the file (other crates use version.workspace = true).
+# Helper: write UTF-8 WITHOUT a byte-order mark.
+# Windows PowerShell 5.1's `Set-Content -Encoding utf8` writes UTF-8 WITH BOM
+# (uses the .NET Framework Encoding.UTF8). PowerShell 7+ added `utf8NoBOM` but
+# we can't rely on that. Use .NET directly with UTF8Encoding($false) for an
+# encoding that is consistent across PS 5.1 and 7+.
+function Write-Utf8NoBom {
+    param([string]$Path, [string]$Content)
+    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+    [System.IO.File]::WriteAllText($Path, $Content, $utf8NoBom)
+}
+
+# Update Cargo.toml [workspace.package] version.
+# `\s*$` instead of `$` so the regex tolerates CRLF line endings on Windows
+# (the \r between the closing quote and \n is whitespace).
+# This is the only `version = "..."` line in the file; other crates use
+# version.workspace = true.
 $cargoContent = Get-Content $CargoToml -Raw
-if (-not ($cargoContent -match '(?m)^version = "[^"]*"$')) {
-    Write-Error "Could not find a 'version = \"...\"' line to replace in $CargoToml"
+if (-not ($cargoContent -match '(?m)^version = "[^"]*"\s*$')) {
+    Write-Error "Could not find a version = `"...`" line to replace in $CargoToml"
     exit 1
 }
-$cargoUpdated = $cargoContent -replace '(?m)^version = "[^"]*"$', "version = `"$Version`""
-Set-Content -Path $CargoToml -Value $cargoUpdated -NoNewline -Encoding utf8
+$cargoUpdated = $cargoContent -replace '(?m)^version = "[^"]*"', "version = `"$Version`""
+Write-Utf8NoBom -Path $CargoToml -Content $cargoUpdated
 
 # Update tauri.conf.json "version" via targeted regex (NOT ConvertTo-Json,
 # which reformats indentation + reorders properties + corrupts the file).
-# -Encoding utf8 explicitly so Windows PowerShell 5.1 doesn't write a different
-# default encoding.
 $confContent = Get-Content $TauriConf -Raw
 if (-not ($confContent -match '"version"\s*:\s*"[^"]*"')) {
-    Write-Error "Could not find a '\"version\": \"...\"' line to replace in $TauriConf"
+    Write-Error "Could not find a `"version`": `"...`" line to replace in $TauriConf"
     exit 1
 }
 $confUpdated = $confContent -replace '("version"\s*:\s*)"[^"]*"', "`$1`"$Version`""
-Set-Content -Path $TauriConf -Value $confUpdated -NoNewline -Encoding utf8
+Write-Utf8NoBom -Path $TauriConf -Content $confUpdated
 
 Write-Host "Bumped version to $Version in:" -ForegroundColor Green
 Write-Host "  - $CargoToml"


### PR DESCRIPTION
## Summary

Three real bugs in `scripts/release.ps1` that surfaced when actually running it on Windows PowerShell 5.1 to cut the v0.1.0 release. The test runs in PR #147 only verified syntax (tokenization), not behavior. All three are addressed in one commit.

## What was broken

### 1. CRLF-intolerant regex
The Cargo.toml regex used `(?m)^version = "[^"]*"$`. In .NET regex with multiline mode, `$` matches immediately before `\n`. On Windows the file has CRLF line endings — the `\r` between the closing quote and `\n` breaks the anchor. Match silently failed; script bailed via the "Could not find" guard.

Fix: `\s*$` instead of `$` in the existence-check regex (whitespace absorbs the `\r`). Replace regex doesn't anchor on end (matches up to closing quote only), so unaffected.

### 2. `Write-Error` string escaping
The error messages used literal `\"...\"` inside double-quoted PowerShell strings:
```powershell
Write-Error "Could not find a 'version = \"...\"' line to replace in $CargoToml"
```
PowerShell treats `\"` as `\` + string-terminator (the parser doesn't recognize `\"` as an escape). The string ended at the first quote, the rest was interpreted as positional args, producing this user-visible error:
```
A positional parameter cannot be found that accepts argument '...\' line to replace in C:\Users\theni\documents\brawltome\apps\desktop\Cargo.toml'.
```

Fix: backtick-escape the inner quotes (`` `" ``).

### 3. UTF-8 BOM written on Windows PS 5.1
Windows PowerShell 5.1's `Set-Content -Encoding utf8` writes UTF-8 WITH a BOM (uses .NET Framework's `Encoding.UTF8`, which has the preamble enabled). PowerShell 7+ added `utf8NoBOM` for the no-BOM variant, but we can't rely on PS7 being installed.

Test run with the previous version added a BOM (`﻿`) to both Cargo.toml and tauri.conf.json, which would have committed BOM-prefixed files on the first real release.

Fix: replaced both `Set-Content -Encoding utf8` calls with a `Write-Utf8NoBom` helper that uses `[System.Text.UTF8Encoding]::new($false)` directly via `[System.IO.File]::WriteAllText`. Produces identical output across PS 5.1 and 7+.

## Verification

Ran `powershell -NoProfile -Command "& ./scripts/release.ps1 0.1.0"` after the fix:
- No errors
- Cargo.toml first 5 bytes: `[work` (no BOM)
- tauri.conf.json first 5 bytes: `{\r\n` (no BOM)
- "No file changes (version was already 0.1.0). Tagging current HEAD." path triggered correctly
- v0.1.0 tag created at HEAD

(Tag was deleted before commit; will be re-created when the user runs the script after this hotfix merges.)

## Test plan

- [x] Manual run of script with same-version case verified
- [ ] CI passes
- [ ] After merge: re-run `./scripts/release.ps1 0.1.0` on master, push tag, verify Desktop Release workflow builds + uploads