### PR TITLE
fix(release): call existing 'build' script not nonexistent 'tauri' script

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -43,11 +43,13 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build Tauri release bundle
-        working-directory: apps/desktop
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-        run: bun run --filter @brawltome/desktop tauri build
+        # Calls the existing `build` script in apps/desktop/package.json which
+        # invokes `tauri build`. `bun run --filter <pkg> tauri build` doesn't
+        # work because there's no script literally named "tauri".
+        run: bun run --filter @brawltome/desktop build
 
       - name: Locate built artifacts
         id: artifacts


### PR DESCRIPTION
## Summary

The v0.1.0 release run failed at the build step with `No packages matched the filter`. Same bun-filter mistake we hit during keypair generation: `bun run --filter @brawltome/desktop tauri build` looks for a script literally named `tauri` in the desktop package, but the package only has `dev`, `build`, and `typecheck` (the `build` script wraps `tauri build`).

## Fix

Call the existing `build` script: `bun run --filter @brawltome/desktop build`. Also dropped the redundant `working-directory: apps/desktop` since the bun-filter form runs in the package's own directory regardless of the workflow's working directory.

## Recovery for v0.1.0

After this PR merges, the user will:
1. Delete the existing v0.1.0 tag (locally + remote)
2. Re-run `./scripts/release.ps1 0.1.0` to recreate it at the new master HEAD
3. Push tag → triggers fixed Desktop Release workflow

(I'll walk through the commands once this is in.)

## Test plan

- [ ] CI passes
- [ ] After merge: re-tag v0.1.0, push, watch Desktop Release workflow build + upload installer + sig + latest.json