### PR TITLE
fix(release): bundle path uses workspace target dir not per-package

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -56,7 +56,10 @@ jobs:
         shell: pwsh
         run: |
           $version = "${{ github.ref_name }}".TrimStart('v')
-          $bundleDir = "apps/desktop/app/target/release/bundle/nsis"
+          # Cargo workspaces output to the WORKSPACE target dir (apps/desktop/target),
+          # not per-package (apps/desktop/app/target). tauri-cli detects the workspace
+          # and follows that convention.
+          $bundleDir = "apps/desktop/target/release/bundle/nsis"
           $exe = Get-ChildItem -Path $bundleDir -Filter "*-setup.exe" | Select-Object -First 1
           $sig = Get-ChildItem -Path $bundleDir -Filter "*-setup.exe.sig" | Select-Object -First 1
           if (-not $exe) { Write-Error "No installer .exe found in $bundleDir"; exit 1 }


### PR DESCRIPTION
## Summary

The 'Locate built artifacts' step looked at `apps/desktop/app/target/release/bundle/nsis` which doesn't exist in a Cargo workspace setup. Workspaces output to the workspace's shared `target/`, so the actual path is `apps/desktop/target/release/bundle/nsis`. Confirmed by the user's local build output.

## Test plan

- [x] Verified the actual bundle path on the user's local successful build
- [ ] CI green
- [ ] After merge: re-tag v0.1.0, push, full Desktop Release pipeline succeeds end-to-end

## Pattern

Three of the four release-workflow bugs we hit this session would have been caught by a local pre-flight build (which the user can run before any tag push). Adding that as an automatic gate to `scripts/release.ps1` in a follow-up so future releases can't burn CI minutes on locally-detectable failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the desktop release workflow to properly locate built artifacts from the workspace output directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->