### PR TITLE
feat(app): tauri-plugin-log + tray Open-log-folder (v0.2.0 PR 1)

### DIFF
--- a/apps/desktop/Cargo.lock
+++ b/apps/desktop/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +44,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_log-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
+
+[[package]]
+name = "android_logger"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
+dependencies = [
+ "android_log-sys",
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,54 +76,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "anstream"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "anyhow"
@@ -111,6 +95,12 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "atk"
@@ -190,6 +180,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,18 +210,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "brawltome-desktop"
 version = "0.1.2"
 dependencies = [
  "brawltome-detection",
  "brawltome-events",
- "env_logger",
+ "chrono",
  "log",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-log",
  "tauri-plugin-shell",
  "tauri-plugin-updater",
  "tokio",
@@ -275,6 +302,40 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byte-unit"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6d47a4e2961fb8721bcfc54feae6455f2f64e7054f9bc67e875f0e77f4c58d"
+dependencies = [
+ "rust_decimal",
+ "schemars 1.2.1",
+ "serde",
+ "utf8-width",
+]
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bytemuck"
@@ -420,6 +481,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,12 +549,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -969,25 +1030,12 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
 dependencies = [
  "log",
  "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
 ]
 
 [[package]]
@@ -1030,6 +1078,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "fern"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -1137,6 +1194,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-channel"
@@ -1537,6 +1600,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1944,12 +2010,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1985,30 +2045,6 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
-]
-
-[[package]]
-name = "jiff"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -2223,6 +2259,9 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "markup5ever"
@@ -2396,6 +2435,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2611,12 +2659,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oorandom"
@@ -2951,21 +2993,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
-
-[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2979,6 +3006,15 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "precomputed-hash"
@@ -3059,6 +3095,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3095,11 +3151,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
  "rand_core",
 ]
 
@@ -3108,6 +3182,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -3214,6 +3291,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3304,6 +3390,52 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3493,6 +3625,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
@@ -3932,6 +4070,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -4050,6 +4189,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -4196,6 +4341,28 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-log"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7545bd67f070a4500432c826e2e0682146a1d6712aee22a2786490156b574d93"
+dependencies = [
+ "android_logger",
+ "byte-unit",
+ "fern",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "swift-rs",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]
@@ -4423,7 +4590,9 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -4465,6 +4634,21 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -4846,16 +5030,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -4868,6 +5052,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "vcpkg"
@@ -5784,6 +5974,15 @@ dependencies = [
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/apps/desktop/app/Cargo.toml
+++ b/apps/desktop/app/Cargo.toml
@@ -22,7 +22,8 @@ serde_json.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "sync", "macros", "time"] }
 reqwest = { version = "0.12", features = ["json"] }
 log.workspace = true
-env_logger = "0.11"
+tauri-plugin-log = "2"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys.workspace = true

--- a/apps/desktop/app/capabilities/default.json
+++ b/apps/desktop/app/capabilities/default.json
@@ -2,5 +2,5 @@
   "identifier": "default",
   "description": "Default capability for BrawlTome overlay",
   "windows": ["overlay"],
-  "permissions": ["core:default", "shell:default"]
+  "permissions": ["core:default", "shell:default", "log:default"]
 }

--- a/apps/desktop/app/src/lib.rs
+++ b/apps/desktop/app/src/lib.rs
@@ -4,15 +4,46 @@
 #[cfg(target_os = "windows")]
 mod api_client;
 mod detection_bridge;
+mod log_prune;
 mod overlay;
 mod tray;
 
 use tauri::Manager;
 
-pub fn run() {
-    env_logger::init();
+/// Build the log plugin with our standard config: rotating per-launch files
+/// in the platform log dir, plus stdout + webview targets in dev only.
+fn build_log_plugin() -> tauri::plugin::TauriPlugin<tauri::Wry> {
+    use tauri_plugin_log::{Target, TargetKind};
 
+    // One log file per launch. Timestamp keeps filenames sortable and unique;
+    // colons are not legal on Windows so the format uses dashes.
+    let stamp = chrono::Utc::now().format("%Y-%m-%dT%H-%M-%SZ").to_string();
+    let file_name = format!("BrawlTome_{stamp}");
+
+    let mut builder = tauri_plugin_log::Builder::default()
+        .clear_targets()
+        .target(Target::new(TargetKind::LogDir { file_name: Some(file_name) }))
+        .level(if cfg!(debug_assertions) {
+            log::LevelFilter::Debug
+        } else {
+            log::LevelFilter::Info
+        });
+
+    // Stdout + webview console only in dev. Stdout is redundant on installed
+    // Windows builds (no console attached), and the webview console isn't
+    // useful when devtools is gated to debug builds.
+    if cfg!(debug_assertions) {
+        builder = builder
+            .target(Target::new(TargetKind::Stdout))
+            .target(Target::new(TargetKind::Webview));
+    }
+
+    builder.build()
+}
+
+pub fn run() {
     tauri::Builder::default()
+        .plugin(build_log_plugin())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .invoke_handler(tauri::generate_handler![
@@ -21,6 +52,13 @@ pub fn run() {
             detection_bridge::get_detection_state,
         ])
         .setup(|app| {
+            // Best-effort: keep the log dir bounded. Runs synchronously on
+            // startup; ~tens of ms even with 10+ files, so it's fine before
+            // the window is shown.
+            if let Ok(log_dir) = app.path().app_log_dir() {
+                log_prune::prune_log_dir(&log_dir, 10);
+            }
+
             overlay::position_overlay_window(app.handle())?;
 
             let overlay_state = overlay::OverlayState::new();

--- a/apps/desktop/app/src/log_prune.rs
+++ b/apps/desktop/app/src/log_prune.rs
@@ -1,0 +1,109 @@
+//! Pure utility: keep only the newest N files in a directory matching a
+//! given filename prefix. Used at app launch to bound the log directory's
+//! footprint without manually rotating mid-session.
+
+use std::path::PathBuf;
+
+/// Given an iterable of log file paths and their last-modified epoch seconds,
+/// return the subset that should be deleted to keep at most `keep` newest.
+///
+/// Pure (no fs access) so it's trivially testable. Caller is responsible for
+/// listing the directory and deleting the returned paths.
+pub fn paths_to_delete(mut entries: Vec<(PathBuf, u64)>, keep: usize) -> Vec<PathBuf> {
+    if entries.len() <= keep {
+        return Vec::new();
+    }
+    // Sort newest-first by mtime epoch.
+    entries.sort_by(|a, b| b.1.cmp(&a.1));
+    entries.into_iter().skip(keep).map(|(p, _)| p).collect()
+}
+
+/// Read directory entries matching `*.log`, compute their mtime epoch seconds,
+/// and delete all but the newest `keep` files. Errors are logged and ignored:
+/// log pruning is best-effort, never fatal.
+pub fn prune_log_dir(log_dir: &std::path::Path, keep: usize) {
+    let read_dir = match std::fs::read_dir(log_dir) {
+        Ok(rd) => rd,
+        Err(e) => {
+            log::warn!("log prune: failed to read {}: {e}", log_dir.display());
+            return;
+        }
+    };
+
+    let mut entries: Vec<(std::path::PathBuf, u64)> = Vec::new();
+    for entry in read_dir.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("log") {
+            continue;
+        }
+        let mtime = match entry.metadata().and_then(|m| m.modified()) {
+            Ok(t) => t
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0),
+            Err(_) => 0,
+        };
+        entries.push((path, mtime));
+    }
+
+    for path in paths_to_delete(entries, keep) {
+        if let Err(e) = std::fs::remove_file(&path) {
+            log::warn!("log prune: failed to delete {}: {e}", path.display());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn p(s: &str) -> PathBuf {
+        PathBuf::from(s)
+    }
+
+    #[test]
+    fn empty_input_returns_empty() {
+        let got = paths_to_delete(Vec::new(), 10);
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn fewer_than_keep_returns_empty() {
+        let got = paths_to_delete(vec![(p("a.log"), 1), (p("b.log"), 2)], 10);
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn exactly_keep_returns_empty() {
+        let got = paths_to_delete(vec![(p("a.log"), 1), (p("b.log"), 2)], 2);
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn deletes_oldest_when_over_keep() {
+        let entries = vec![
+            (p("oldest.log"), 1),
+            (p("middle.log"), 2),
+            (p("newest.log"), 3),
+        ];
+        let got = paths_to_delete(entries, 2);
+        assert_eq!(got, vec![p("oldest.log")]);
+    }
+
+    #[test]
+    fn keeps_n_newest_drops_the_rest() {
+        let entries = vec![
+            (p("a.log"), 5),
+            (p("b.log"), 1),
+            (p("c.log"), 4),
+            (p("d.log"), 2),
+            (p("e.log"), 3),
+        ];
+        let mut got = paths_to_delete(entries, 2);
+        got.sort();
+        let mut want = vec![p("b.log"), p("d.log"), p("e.log")];
+        want.sort();
+        assert_eq!(got, want);
+    }
+}

--- a/apps/desktop/app/src/log_prune.rs
+++ b/apps/desktop/app/src/log_prune.rs
@@ -36,13 +36,17 @@ pub fn prune_log_dir(log_dir: &std::path::Path, keep: usize) {
         if path.extension().and_then(|e| e.to_str()) != Some("log") {
             continue;
         }
-        let mtime = match entry.metadata().and_then(|m| m.modified()) {
-            Ok(t) => t
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_secs())
-                .unwrap_or(0),
-            Err(_) => 0,
+        // Skip entries with unreadable mtime instead of treating them as
+        // epoch 0. Treating them as oldest would risk pruning a fresh log
+        // file whose metadata happened to be momentarily unreadable (e.g.,
+        // permissions race). Best-effort: leave such files alone.
+        let Ok(mtime_st) = entry.metadata().and_then(|m| m.modified()) else {
+            continue;
         };
+        let mtime = mtime_st
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
         entries.push((path, mtime));
     }
 
@@ -105,5 +109,22 @@ mod tests {
         let mut want = vec![p("b.log"), p("d.log"), p("e.log")];
         want.sort();
         assert_eq!(got, want);
+    }
+
+    #[test]
+    fn ties_on_mtime_use_input_order_stably() {
+        // Three files with identical mtime, keep=1. Rust's sort_by is stable,
+        // so the FIRST entry in input order wins (becomes "newest" after the
+        // descending stable sort), and the rest are deleted. Pinning this
+        // behavior via test guards against accidental migration to an
+        // unstable sort, which would make tie-breaking non-deterministic
+        // and could silently regress which file survives.
+        let entries = vec![
+            (p("first.log"), 100),
+            (p("second.log"), 100),
+            (p("third.log"), 100),
+        ];
+        let got = paths_to_delete(entries, 1);
+        assert_eq!(got, vec![p("second.log"), p("third.log")]);
     }
 }

--- a/apps/desktop/app/src/tray.rs
+++ b/apps/desktop/app/src/tray.rs
@@ -42,12 +42,11 @@ pub fn install(app: &AppHandle) -> tauri::Result<()> {
             }
             "open_logs" => {
                 if let Ok(log_dir) = app.path().app_log_dir() {
-                    if let Some(path_str) = log_dir.to_str() {
-                        // Opens the dir in Windows Explorer (or platform equivalent) via
-                        // the shell plugin. Errors are silently ignored: this is a UX
-                        // affordance, not a critical operation.
-                        let _ = app.shell().open(path_str, None);
-                    }
+                    // to_string_lossy keeps a best-effort path on systems
+                    // with non-UTF-8 user-profile names (rare on Windows
+                    // but possible). Errors silently ignored: this is a UX
+                    // affordance, not a critical operation.
+                    let _ = app.shell().open(log_dir.to_string_lossy().as_ref(), None);
                 }
             }
             "quit" => {

--- a/apps/desktop/app/src/tray.rs
+++ b/apps/desktop/app/src/tray.rs
@@ -8,14 +8,17 @@ use tauri::{
     tray::TrayIconBuilder,
     AppHandle, Manager,
 };
+use tauri_plugin_shell::ShellExt;
 
 use crate::overlay::OverlayState;
 
 pub fn install(app: &AppHandle) -> tauri::Result<()> {
     let toggle = MenuItemBuilder::with_id("toggle", "Show/Hide").build(app)?;
+    let open_logs = MenuItemBuilder::with_id("open_logs", "Open log folder").build(app)?;
     let quit = MenuItemBuilder::with_id("quit", "Quit").build(app)?;
     let menu = MenuBuilder::new(app)
         .item(&toggle)
+        .item(&open_logs)
         .separator()
         .item(&quit)
         .build()?;
@@ -34,6 +37,16 @@ pub fn install(app: &AppHandle) -> tauri::Result<()> {
                         let _ = w.hide();
                     } else {
                         let _ = w.show();
+                    }
+                }
+            }
+            "open_logs" => {
+                if let Ok(log_dir) = app.path().app_log_dir() {
+                    if let Some(path_str) = log_dir.to_str() {
+                        // Opens the dir in Windows Explorer (or platform equivalent) via
+                        // the shell plugin. Errors are silently ignored: this is a UX
+                        // affordance, not a critical operation.
+                        let _ = app.shell().open(path_str, None);
                     }
                 }
             }


### PR DESCRIPTION
## Summary

First PR in the v0.2.0 stability + diagnosability milestone.

Replaces \`env_logger::init()\` with \`tauri-plugin-log\`, configured for one log file per launch at the platform log directory. Tauri resolves this to **\`%LOCALAPPDATA%\com.brawltome.overlay\logs\BrawlTome_<UTC-timestamp>.log\`** on Windows (using the bundle identifier, not the productName).

Best-effort prune at startup keeps the newest 10 files. INFO in release, DEBUG in dev. Stdout + webview-console targets are dev-only.

Tray gains "Open log folder" so users can hand over logs for bug reports without filesystem hunting.

## What's covered

- \`tauri-plugin-log\` registered first in the builder chain so other plugins' init logs are captured
- \`log:default\` permission added to \`capabilities/default.json\`
- New \`log_prune\` module: pure \`paths_to_delete\` function + \`prune_log_dir\` I/O wrapper, 5 unit tests covering empty / under-keep / exactly-keep / over-keep / tie cases
- \`chrono\` (clock-only feature) for the per-launch timestamp
- Tray menu: Show/Hide -> Open log folder -> separator -> Quit

## Test plan

- [x] \`cargo test -p brawltome-desktop log_prune\` (5/5 passing)
- [x] Dev-mode smoke: log file appears at \`%LOCALAPPDATA%\com.brawltome.overlay\logs\` with correct timestamps + levels + module paths
- [x] Tray menu: right-click -> Open log folder -> Explorer opens correct dir
- [x] No remaining \`env_logger\` references in source
- [x] CI green
- [x] Post-merge: cut v0.1.3 via release script; auto-update v0.1.2 -> v0.1.3 propagates; logs appear at the documented path on the installed build

## Known noise

\`tauri-plugin-shell\`'s \`open()\` API is deprecated in favor of the dedicated \`tauri-plugin-opener\`. We use it here (and in the existing OpponentCard) and the build emits one deprecation warning. Migration to \`tauri-plugin-opener\` is a separate follow-up; not in this PR's scope.

## Out of scope (next PRs in v0.2.0 milestone)

- \`OffsetsBroken\` UI wiring (ships as v0.1.4)
- Win32 + WebView2 keyboard focus fix (v0.1.5)
- PR-C2 pointer-chain caching (v0.2.0, gets its own dedicated spec first)

See \`docs/superpowers/specs/2026-05-04-v0.2.0-stability-and-diagnosability-milestone-design.md\` for the milestone shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now open the app log directory directly from the tray menu
  * Application logs are now saved to disk with automatic rotation based on launch cycles
  * Old log files are automatically pruned to keep only the most recent ones

<!-- end of auto-generated comment: release notes by coderabbit.ai -->