### PR TITLE
fix(release): prompt for signing-key password instead of hardcoding empty

### DIFF
--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -88,7 +88,20 @@ if ($keyBytes.Length -ge 3 -and $keyBytes[0] -eq 0xEF -and $keyBytes[1] -eq 0xBB
     $keyBytes = $keyBytes[3..($keyBytes.Length-1)]
 }
 $env:TAURI_SIGNING_PRIVATE_KEY = [System.Text.Encoding]::UTF8.GetString($keyBytes)
-$env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = ""
+
+# If the key is password-protected, prompt for it. Empty = passwordless key.
+# The previous version hardcoded "" here, which caused tauri-bundler's signing
+# step to silently hang on stdin waiting for the password (no TTY = silent
+# hang). Symptom: "Finished 1 bundle at ..." prints, then nothing. Read-Host
+# -AsSecureString avoids echoing the password to the terminal; we convert to
+# plaintext only inside this process's env vars and clear them after.
+$securePass = Read-Host "Signing-key password (press Enter if none)" -AsSecureString
+$bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($securePass)
+try {
+    $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
+} finally {
+    [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+}
 
 & bun run --filter @brawltome/desktop build
 $buildExit = $LASTEXITCODE

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -101,6 +101,10 @@ try {
     $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
 } finally {
     [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+    # Dispose the SecureString to zero its encrypted pinned buffer instead of
+    # waiting for GC finalization. The BSTR cleanup above only handles the
+    # decrypted copy.
+    $securePass.Dispose()
 }
 
 & bun run --filter @brawltome/desktop build


### PR DESCRIPTION
## Summary

Patches \`scripts/release.ps1\` to prompt for the signing-key password instead of hardcoding it to empty string.

## Why

Encountered while cutting v0.1.4: the script's pre-flight build hung silently for minutes after \`Finished 1 bundle at ...\` because tauri-bundler was reading from stdin waiting for the Ed25519 key password. The previous code set \`\$env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = \"\"\` unconditionally, so password-protected keys couldn't be unlocked, and the silent stdin wait looked like a hang.

Worked around v0.1.4 by skipping pre-flight (committed + tagged + pushed manually; CI built the signed bundle from its own GitHub Actions secret). This PR fixes the local pre-flight path so future releases don't trip on the same issue.

## What changed

- Replace the hardcoded empty string with \`Read-Host -AsSecureString\` so the password is prompted at the terminal without echo.
- Convert SecureString -> BSTR -> plaintext for the env var (tauri-bundler reads it that way), then zero the BSTR backing buffer.
- Pressing Enter at the prompt produces an empty string, preserving the prior behavior for passwordless keys.

The existing cleanup at end-of-script (setting \`TAURI_SIGNING_PRIVATE_KEY_PASSWORD = \$null\`) still runs.

## Test plan

- [x] \`PowerShell -NoProfile\` parses the file clean (\`[Parser]::ParseFile\`)
- [ ] Manual run of \`./scripts/release.ps1 0.2.0-test\` in a throwaway branch verifies the prompt appears, accepts input, and the build proceeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release security by replacing hard-coded password handling with a secure, interactive prompt for signing keys. The entered secret is handled safely during the process and cleared from memory afterward to reduce risk. All other pre-release steps remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->