### PR TITLE
refactor(v0.2.0): Phase 1 detection module split + probe import path updates

### DIFF
--- a/apps/desktop/Cargo.lock
+++ b/apps/desktop/Cargo.lock
@@ -241,6 +241,7 @@ dependencies = [
  "brawltome-events",
  "chrono",
  "log",
+ "minidump",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -806,6 +807,15 @@ dependencies = [
  "libc",
  "libdbus-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
 ]
 
 [[package]]
@@ -2281,6 +2291,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2294,6 +2313,41 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minidump"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d385b740c6b991e6eff48f26e2c6978c9e9e9e2e935f4967bcdf4c2d1d18828"
+dependencies = [
+ "debugid",
+ "encoding_rs",
+ "memmap2",
+ "minidump-common",
+ "num-traits",
+ "procfs-core",
+ "range-map",
+ "scroll",
+ "thiserror 1.0.69",
+ "time",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "minidump-common"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c4d14bcca0fd3ed165a03000480aaa364c6860c34e900cb2dafdf3b95340e77"
+dependencies = [
+ "bitflags 2.11.1",
+ "debugid",
+ "num-derive",
+ "num-traits",
+ "range-map",
+ "scroll",
+ "smart-default",
+]
 
 [[package]]
 name = "minisign-verify"
@@ -2405,6 +2459,17 @@ name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "num-traits"
@@ -3095,6 +3160,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs-core"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+dependencies = [
+ "bitflags 2.11.1",
+ "hex",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3184,6 +3259,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "range-map"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12a5a2d6c7039059af621472a4389be1215a816df61aa4d531cfe85264aee95f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -3627,6 +3711,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scroll"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3951,6 +4055,17 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smart-default"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "socket2"
@@ -4880,8 +4995,21 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/apps/desktop/app/Cargo.toml
+++ b/apps/desktop/app/Cargo.toml
@@ -2,6 +2,7 @@
 name = "brawltome-desktop"
 version.workspace = true
 edition.workspace = true
+default-run = "brawltome-desktop"
 
 [lib]
 name = "brawltome_desktop"
@@ -10,6 +11,35 @@ path = "src/lib.rs"
 [[bin]]
 name = "brawltome-desktop"
 path = "src/main.rs"
+
+# Dev-only research binaries. Not included in production builds. Each is
+# behind its own feature flag so a default cargo build does not pull them in.
+
+[[bin]]
+name = "pointer_scan"
+path = "src/bin/pointer_scan.rs"
+required-features = ["pointer-scan-tool"]
+
+[[bin]]
+name = "intmap_probe"
+path = "src/bin/intmap_probe.rs"
+required-features = ["intmap-probe-tool"]
+
+[[bin]]
+name = "dump_layout"
+path = "src/bin/dump_layout.rs"
+required-features = ["dump-layout-tool"]
+
+[[bin]]
+name = "login_probe"
+path = "src/bin/login_probe.rs"
+required-features = ["login-probe-tool"]
+
+[features]
+pointer-scan-tool = ["dep:minidump"]
+intmap-probe-tool = []
+dump-layout-tool = []
+login-probe-tool = []
 
 [dependencies]
 brawltome-events.workspace = true
@@ -24,6 +54,7 @@ reqwest = { version = "0.12", features = ["json"] }
 log.workspace = true
 tauri-plugin-log = "2"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+minidump = { version = "0.21", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys.workspace = true

--- a/apps/desktop/app/src/bin/dump_layout.rs
+++ b/apps/desktop/app/src/bin/dump_layout.rs
@@ -37,7 +37,7 @@ use std::path::PathBuf;
 use std::time::SystemTime;
 
 use brawltome_detection::memory::{self, RegionCache};
-use brawltome_detection::scanner;
+use brawltome_detection::{locate, scan};
 
 use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
 use windows_sys::Win32::System::Diagnostics::ToolHelp::{
@@ -89,7 +89,7 @@ fn main() {
     let mut cache = RegionCache::new(regions);
     println!("Region cache built: {} regions", cache.regions.len());
 
-    let my_bhid = match scanner::find_my_bhid(handle, &mut cache) {
+    let my_bhid = match locate::find_my_bhid(handle, &mut cache) {
         Some(b) => b,
         None => {
             eprintln!("Local BhID not found (are you logged in?)");
@@ -100,7 +100,7 @@ fn main() {
 
     let bhid_value_addr = locate_bhid_value(handle, my_bhid, &cache);
 
-    let addr_04c = scanner::find_04c_addr(handle, my_bhid, &cache);
+    let addr_04c = locate::find_04c_addr(handle, my_bhid, &cache);
     println!("04c address: {:?}", addr_04c.map(|a| format!("0x{:016x}", a)));
 
     // Pull atom-match addresses BEFORE get_players (which clears them via
@@ -112,7 +112,7 @@ fn main() {
     let atom_addrs = memory::scan_regions(handle, &regions, &atom_bytes);
     println!("IntMap atom matches: {}", atom_addrs.len());
 
-    let players = scanner::get_players(handle, my_bhid, &mut cache, &HashSet::new());
+    let players = scan::get_players(handle, my_bhid, &mut cache, &HashSet::new());
     println!("Players: {}", players.len());
     for (bhid, p) in &players {
         println!("  bhid={} slot={} name={:?}", bhid, p.slot, p.name);

--- a/apps/desktop/app/src/bin/dump_layout.rs
+++ b/apps/desktop/app/src/bin/dump_layout.rs
@@ -1,0 +1,395 @@
+//! Standalone debug binary for the PR-C2 pointer-chain investigation.
+//!
+//! Run this from a terminal while you're in an actual matchmaking match
+//! (custom rooms use a different code path and would point at the wrong
+//! IntMap). It opens Brawlhalla.exe, runs the existing scanner logic to
+//! locate the player IntMap entries / 04c address / local BhID, then writes
+//! a `.txt` file documenting:
+//!
+//! - Brawlhalla.exe module base + size (so any address can be expressed as
+//!   `module + offset`, which is what Cheat Engine pointer-scan needs as
+//!   the "stable anchor" output).
+//! - Local BhID and the address where its u32 value lives.
+//! - 04c (connection-state) address.
+//! - Every IntMap atom-match address (each is inside an IntMap entry; the
+//!   IntMap base sits 16-byte-aligned somewhere before each match).
+//! - Every player struct pointer (raw + module-relative).
+//! - First 96 bytes of each player struct, hex dumped with field offsets
+//!   annotated, so layout drift is visible at a glance.
+//!
+//! Usage:
+//!   cargo run -p brawltome-desktop --bin dump_layout
+//!
+//! After capturing a `.txt` per match, also right-click Brawlhalla.exe in
+//! Task Manager and "Create dump file". Save the .DMP alongside the .txt.
+//! Cheat Engine can attach to the .DMP for offline pointer scanning, so
+//! you only need the live process for the brief capture window.
+//!
+//! Repeat over 5+ matches across 5+ Brawlhalla launches to gather enough
+//! snapshots that pointer-chain stability across launches can be verified
+//! offline.
+
+use std::collections::HashSet;
+use std::fs::File;
+use std::io::Write;
+use std::mem;
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+use brawltome_detection::memory::{self, RegionCache};
+use brawltome_detection::scanner;
+
+use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
+use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+    CreateToolhelp32Snapshot, Module32FirstW, Module32NextW, MODULEENTRY32W, TH32CS_SNAPMODULE,
+    TH32CS_SNAPMODULE32,
+};
+
+const INVALID_HANDLE: HANDLE = -1isize as HANDLE;
+
+fn main() {
+    let pid = match memory::find_process_id("Brawlhalla.exe") {
+        Some(p) => p,
+        None => {
+            eprintln!("Brawlhalla.exe not running");
+            std::process::exit(1);
+        }
+    };
+    println!("Brawlhalla.exe PID: {pid}");
+
+    let handle = match memory::open_process(pid) {
+        Some(h) => h,
+        None => {
+            eprintln!("Failed to open process (run terminal as admin)");
+            std::process::exit(1);
+        }
+    };
+
+    let modules = enumerate_modules(pid);
+    if modules.is_empty() {
+        eprintln!("Couldn't enumerate modules");
+        std::process::exit(1);
+    }
+    println!("Modules loaded: {}", modules.len());
+    // Largest few likely include the Adobe AIR runtime (where game code lives,
+    // not Brawlhalla.exe which is just a small shim launcher).
+    let mut by_size = modules.clone();
+    by_size.sort_by(|a, b| b.size.cmp(&a.size));
+    for m in by_size.iter().take(5) {
+        println!(
+            "  {:>10} bytes ({:>5.1} MB)  base 0x{:016x}  {}",
+            m.size,
+            m.size as f64 / 1048576.0,
+            m.base,
+            m.name
+        );
+    }
+
+    let regions = memory::heap_regions(handle);
+    let mut cache = RegionCache::new(regions);
+    println!("Region cache built: {} regions", cache.regions.len());
+
+    let my_bhid = match scanner::find_my_bhid(handle, &mut cache) {
+        Some(b) => b,
+        None => {
+            eprintln!("Local BhID not found (are you logged in?)");
+            std::process::exit(1);
+        }
+    };
+    println!("Local BhID: {my_bhid}");
+
+    let bhid_value_addr = locate_bhid_value(handle, my_bhid, &cache);
+
+    let addr_04c = scanner::find_04c_addr(handle, my_bhid, &cache);
+    println!("04c address: {:?}", addr_04c.map(|a| format!("0x{:016x}", a)));
+
+    // Pull atom-match addresses BEFORE get_players (which clears them via
+    // its internal logic). We re-scan here directly so we have the raw
+    // addresses for the dump.
+    let atom_val = (my_bhid as u64).wrapping_shl(3) | 6;
+    let atom_bytes = (atom_val as u32).to_le_bytes();
+    let regions: Vec<memory::MemoryRegion> = cache.regions.clone();
+    let atom_addrs = memory::scan_regions(handle, &regions, &atom_bytes);
+    println!("IntMap atom matches: {}", atom_addrs.len());
+
+    let players = scanner::get_players(handle, my_bhid, &mut cache, &HashSet::new());
+    println!("Players: {}", players.len());
+    for (bhid, p) in &players {
+        println!("  bhid={} slot={} name={:?}", bhid, p.slot, p.name);
+    }
+
+    // Dump file path
+    let local_appdata =
+        std::env::var("LOCALAPPDATA").unwrap_or_else(|_| ".".to_string());
+    let dumps_dir = PathBuf::from(local_appdata)
+        .join("com.brawltome.overlay")
+        .join("dumps");
+    if let Err(e) = std::fs::create_dir_all(&dumps_dir) {
+        eprintln!("Couldn't create {}: {}", dumps_dir.display(), e);
+        std::process::exit(1);
+    }
+    let stamp = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let txt_path = dumps_dir.join(format!("dump_{stamp}.txt"));
+
+    let mut f = match File::create(&txt_path) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("Failed to create {}: {}", txt_path.display(), e);
+            std::process::exit(1);
+        }
+    };
+
+    let _ = writeln!(f, "=== BrawlTome PR-C2 Layout Dump ===");
+    let _ = writeln!(f, "Captured: {stamp} (UTC seconds since epoch)");
+    let _ = writeln!(f, "Brawlhalla.exe PID: {pid}");
+    let _ = writeln!(f, "Heap prefix:  {:?}", cache.heap_prefix);
+    let _ = writeln!(f, "Atom prefix:  {:?}", cache.atom_prefix);
+    let _ = writeln!(f);
+
+    let _ = writeln!(
+        f,
+        "=== Loaded modules ({}, sorted by size) ===",
+        modules.len()
+    );
+    let _ = writeln!(
+        f,
+        "Brawlhalla.exe is a tiny shim. Game code lives in the largest non-system DLLs"
+    );
+    let _ = writeln!(
+        f,
+        "(typically Adobe AIR / Flash runtime). Pointer-scan static anchors come from these."
+    );
+    let _ = writeln!(f);
+    for m in by_size.iter().take(20) {
+        let _ = writeln!(
+            f,
+            "  {:>10} bytes ({:>5.1} MB)  base 0x{:016x}..0x{:016x}  {}",
+            m.size,
+            m.size as f64 / 1048576.0,
+            m.base,
+            m.base + m.size,
+            m.name
+        );
+    }
+    let _ = writeln!(f);
+
+    let _ = writeln!(f, "=== Local Player ===");
+    let _ = writeln!(f, "BhID: {my_bhid}");
+    if let Some(addr) = bhid_value_addr {
+        let _ = writeln!(
+            f,
+            "BhID value address: 0x{:016x} ({})",
+            addr,
+            address_in_modules(&modules, addr)
+        );
+    } else {
+        let _ = writeln!(f, "BhID value address: <not located>");
+    }
+    if let Some(addr) = addr_04c {
+        let _ = writeln!(
+            f,
+            "04c address:        0x{:016x} ({})",
+            addr,
+            address_in_modules(&modules, addr)
+        );
+    } else {
+        let _ = writeln!(f, "04c address:        <not located>");
+    }
+    let _ = writeln!(f);
+
+    let _ = writeln!(
+        f,
+        "=== IntMap atom matches ({} total; first 64 listed) ===",
+        atom_addrs.len()
+    );
+    let _ = writeln!(
+        f,
+        "Each address is inside a 16-byte IntMap entry [atom u32 | pad u32 | ptr u64]."
+    );
+    let _ = writeln!(
+        f,
+        "The IntMap base is at addr - (entry_index * 16). Pointer-scan this address in CE."
+    );
+    let _ = writeln!(f);
+    for (i, addr) in atom_addrs.iter().take(64).enumerate() {
+        let _ = writeln!(
+            f,
+            "  [{i:>3}] 0x{:016x} ({})",
+            addr,
+            address_in_modules(&modules, *addr)
+        );
+    }
+    let _ = writeln!(f);
+
+    let _ = writeln!(f, "=== Player struct addresses ===");
+    let _ = writeln!(
+        f,
+        "These are pointers from IntMap entries' ptr field, masked with !7 (NekoVM tag bits)."
+    );
+    let _ = writeln!(f);
+    let mut written = HashSet::new();
+    for (bhid, _player) in &players {
+        if let Some(struct_addr) = locate_player_struct(handle, *bhid, &atom_addrs) {
+            if !written.insert(struct_addr) {
+                continue;
+            }
+            let _ = writeln!(
+                f,
+                "Player BhID {} at 0x{:016x} ({}):",
+                bhid,
+                struct_addr,
+                address_in_modules(&modules, struct_addr)
+            );
+            let mut buf = [0u8; 96];
+            if memory::read_memory(handle, struct_addr, &mut buf) {
+                write_player_hex(&mut f, &buf);
+            } else {
+                let _ = writeln!(f, "  (read failed)");
+            }
+            let _ = writeln!(f);
+        }
+    }
+
+    println!("\nDump written: {}", txt_path.display());
+    println!(
+        "\nNext: open Task Manager -> right-click Brawlhalla.exe -> Create dump file."
+    );
+    println!("Save the .DMP alongside this .txt for offline Cheat Engine analysis.");
+
+    unsafe {
+        CloseHandle(handle);
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Module {
+    name: String,
+    base: usize,
+    size: usize,
+}
+
+fn enumerate_modules(pid: u32) -> Vec<Module> {
+    let snap = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPMODULE | TH32CS_SNAPMODULE32, pid) };
+    if snap == INVALID_HANDLE {
+        return Vec::new();
+    }
+    let mut me = MODULEENTRY32W {
+        dwSize: mem::size_of::<MODULEENTRY32W>() as u32,
+        ..unsafe { mem::zeroed() }
+    };
+    let mut modules = Vec::new();
+    if unsafe { Module32FirstW(snap, &mut me) } != 0 {
+        loop {
+            let name: String = me
+                .szModule
+                .iter()
+                .take_while(|&&c| c != 0)
+                .map(|&c| c as u8 as char)
+                .collect();
+            modules.push(Module {
+                name,
+                base: me.modBaseAddr as usize,
+                size: me.modBaseSize as usize,
+            });
+            if unsafe { Module32NextW(snap, &mut me) } == 0 {
+                break;
+            }
+        }
+    }
+    unsafe { CloseHandle(snap) };
+    modules
+}
+
+fn address_in_modules(modules: &[Module], addr: usize) -> String {
+    for m in modules {
+        if addr >= m.base && addr < m.base + m.size {
+            return format!("{} + 0x{:x}", m.name, addr - m.base);
+        }
+    }
+    let prefix = (addr >> 32) as u32;
+    format!("heap (prefix 0x{:08x})", prefix)
+}
+
+/// Find the address where the local BhID value lives in memory by replicating
+/// `find_my_bhid`'s pattern logic. Used so the dump can record the raw u32
+/// address for cross-referencing with Cheat Engine.
+fn locate_bhid_value(handle: HANDLE, my_bhid: u32, cache: &RegionCache) -> Option<usize> {
+    let pattern: &[u8] = &[0x00, b'h', b'I', b'D', 0x00];
+    let regions: Vec<memory::MemoryRegion> = cache.regions.clone();
+    let addrs = memory::scan_regions(handle, &regions, pattern);
+    for addr in addrs {
+        if addr >= 24 {
+            if let Some(v) = memory::read::<u32>(handle, addr - 24) {
+                if v == my_bhid {
+                    return Some(addr - 24);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Walk atom-match addresses and dereference the IntMap entry's pointer to
+/// find the player struct address for a given BhID.
+fn locate_player_struct(handle: HANDLE, bhid: u32, atom_addrs: &[usize]) -> Option<usize> {
+    let target_atom = ((bhid as u64) << 3) | 6;
+    let target_atom_u32 = target_atom as u32;
+    for &addr in atom_addrs {
+        // Each match is the start of an atom u32. Read the entry: atom (u32),
+        // pad (u32), ptr (u64). If atom matches AND pad is 0, follow the ptr.
+        let mut entry = [0u8; 16];
+        if !memory::read_memory(handle, addr, &mut entry) {
+            continue;
+        }
+        let atom = u32::from_le_bytes([entry[0], entry[1], entry[2], entry[3]]);
+        let pad = u32::from_le_bytes([entry[4], entry[5], entry[6], entry[7]]);
+        if atom != target_atom_u32 || pad != 0 {
+            continue;
+        }
+        let raw_ptr = u64::from_le_bytes([
+            entry[8], entry[9], entry[10], entry[11], entry[12], entry[13], entry[14], entry[15],
+        ]);
+        let ptr = (raw_ptr & !7) as usize;
+        if ptr == 0 {
+            continue;
+        }
+        return Some(ptr);
+    }
+    None
+}
+
+fn write_player_hex<W: Write>(w: &mut W, buf: &[u8]) {
+    // 16 bytes per row, 6 rows = 96 bytes. Annotate known field offsets in
+    // the right margin so layout drift is visible when comparing across
+    // captures or vs scanner.rs constants.
+    let annotations: &[(usize, &str)] = &[
+        (44, "+44 = bhid (u32)"),
+        (60, "+60 = slot (u32)"),
+        (64, "+64 = snid_ptr (u64)"),
+        (80, "+80 = nested_ptr (u64)"),
+    ];
+    for row in 0..(buf.len() / 16) {
+        let off = row * 16;
+        let bytes: String = (0..16)
+            .map(|i| format!("{:02x}", buf[off + i]))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let mut note = String::new();
+        for (a_off, a_text) in annotations {
+            if *a_off >= off && *a_off < off + 16 {
+                if !note.is_empty() {
+                    note.push_str(", ");
+                }
+                note.push_str(a_text);
+            }
+        }
+        if note.is_empty() {
+            let _ = writeln!(w, "  +{:>2}..{:>2}: {}", off, off + 15, bytes);
+        } else {
+            let _ = writeln!(w, "  +{:>2}..{:>2}: {}    // {}", off, off + 15, bytes, note);
+        }
+    }
+}

--- a/apps/desktop/app/src/bin/intmap_probe.rs
+++ b/apps/desktop/app/src/bin/intmap_probe.rs
@@ -1,0 +1,251 @@
+//! Interactive probe for the PR-C2 IntMap-stability question.
+//!
+//! Hypothesis we want to settle: within a single Brawlhalla launch, does the
+//! player IntMap stay at the same address across matches, or is it
+//! reallocated each match? The answer determines whether PR-C2 caches once
+//! per launch or once per match.
+//!
+//! Workflow per launch:
+//!   1. Open Brawlhalla, log in
+//!   2. Run this tool from an admin terminal
+//!   3. Queue match 1, then in-match press Enter to take snapshot 1
+//!   4. End the match, return to menu, queue match 2, then in-match press
+//!      Enter to take snapshot 2
+//!   5. Ctrl+C to exit
+//!   6. Save the resulting session_<pid>_<launch_ts>.txt
+//!
+//! Repeat across 3-5 launches. Within each session file, compare the
+//! "winning candidates" lines between snapshots. Same address = IntMap is at
+//! the same place across matches in that launch.
+//!
+//! Run with:
+//!   cargo run -p brawltome-desktop --bin intmap_probe --features intmap-probe-tool --release
+
+use std::collections::HashSet;
+use std::fs::OpenOptions;
+use std::io::{BufRead, Write};
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use brawltome_detection::memory::{self, RegionCache};
+use brawltome_detection::scanner;
+
+use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
+
+fn main() {
+    let pid = match memory::find_process_id("Brawlhalla.exe") {
+        Some(p) => p,
+        None => {
+            eprintln!("Brawlhalla.exe not running");
+            std::process::exit(1);
+        }
+    };
+    println!("Brawlhalla.exe PID: {pid}");
+
+    let handle = match memory::open_process(pid) {
+        Some(h) => h,
+        None => {
+            eprintln!("Failed to open process (run terminal as admin)");
+            std::process::exit(1);
+        }
+    };
+
+    let regions = memory::heap_regions(handle);
+    let mut cache = RegionCache::new(regions);
+    println!("Region cache built: {} regions", cache.regions.len());
+
+    let my_bhid = match scanner::find_my_bhid(handle, &mut cache) {
+        Some(b) => b,
+        None => {
+            eprintln!("Local BhID not found (are you logged in?)");
+            std::process::exit(1);
+        }
+    };
+    println!("Local BhID: {my_bhid}");
+
+    let launch_ts = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    let local_appdata = std::env::var("LOCALAPPDATA").unwrap_or_else(|_| ".".to_string());
+    let dumps_dir = PathBuf::from(local_appdata)
+        .join("com.brawltome.overlay")
+        .join("dumps");
+    if let Err(e) = std::fs::create_dir_all(&dumps_dir) {
+        eprintln!("Couldn't create {}: {}", dumps_dir.display(), e);
+        std::process::exit(1);
+    }
+    let session_path = dumps_dir.join(format!("session_{pid}_{launch_ts}.txt"));
+    println!("Session log: {}", session_path.display());
+
+    {
+        let mut f = match OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&session_path)
+        {
+            Ok(f) => f,
+            Err(e) => {
+                eprintln!("Couldn't open session file: {e}");
+                std::process::exit(1);
+            }
+        };
+        let _ = writeln!(f, "=== BrawlTome IntMap-Stability Probe Session ===");
+        let _ = writeln!(f, "Brawlhalla PID: {pid}");
+        let _ = writeln!(f, "Launch timestamp: {launch_ts}");
+        let _ = writeln!(f, "Local BhID: {my_bhid}");
+        let _ = writeln!(f, "Heap prefix: {:?}", cache.heap_prefix);
+        let _ = writeln!(f, "Atom prefix: {:?}", cache.atom_prefix);
+        let _ = writeln!(f);
+    }
+
+    let stdin = std::io::stdin();
+    let mut handle_in = stdin.lock();
+    let mut input = String::new();
+    let mut snapshot_id: u32 = 0;
+
+    loop {
+        snapshot_id += 1;
+        println!(
+            "\n--- Press Enter to take snapshot #{snapshot_id} (Ctrl+C to exit). \
+             Make sure you're already in a real matchmaking match. ---"
+        );
+        input.clear();
+        if handle_in.read_line(&mut input).unwrap_or(0) == 0 {
+            break;
+        }
+        capture_snapshot(handle, my_bhid, &mut cache, &session_path, snapshot_id);
+    }
+
+    unsafe {
+        CloseHandle(handle);
+    }
+}
+
+fn capture_snapshot(
+    handle: HANDLE,
+    my_bhid: u32,
+    cache: &mut RegionCache,
+    session_path: &Path,
+    snapshot_id: u32,
+) {
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    println!("Scanning...");
+
+    let atom_val = (my_bhid as u64).wrapping_shl(3) | 6;
+    let atom_bytes = (atom_val as u32).to_le_bytes();
+    let regions: Vec<memory::MemoryRegion> = cache.regions.clone();
+    let atom_addrs = memory::scan_regions(handle, &regions, &atom_bytes);
+
+    let mut per_candidate: Vec<(usize, Vec<(u32, usize)>)> = Vec::new();
+    for &addr in &atom_addrs {
+        let yielded = walk_candidate(handle, addr);
+        per_candidate.push((addr, yielded));
+    }
+
+    let winning: Vec<usize> = per_candidate
+        .iter()
+        .filter(|(_, ys)| !ys.is_empty())
+        .map(|(a, _)| *a)
+        .collect();
+
+    let mut f = match OpenOptions::new().append(true).open(session_path) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("Couldn't append to session file: {e}");
+            return;
+        }
+    };
+
+    let _ = writeln!(f, "=== Snapshot #{snapshot_id} (ts={now}) ===");
+    let _ = writeln!(f, "Atom-match candidates ({}):", per_candidate.len());
+    for (addr, ys) in &per_candidate {
+        if ys.is_empty() {
+            let _ = writeln!(f, "  0x{:016x} -> no valid players", addr);
+        } else {
+            let parts = ys
+                .iter()
+                .map(|(b, p)| format!("bhid={} struct=0x{:016x}", b, p))
+                .collect::<Vec<_>>()
+                .join("; ");
+            let _ = writeln!(f, "  0x{:016x} -> {}", addr, parts);
+        }
+    }
+    let _ = writeln!(f);
+    let _ = writeln!(f, "Winning candidates ({}):", winning.len());
+    for addr in &winning {
+        let _ = writeln!(f, "  0x{:016x}", addr);
+    }
+    let _ = writeln!(f);
+
+    println!(
+        "Snapshot #{snapshot_id}: {} atom-matches, {} winning",
+        per_candidate.len(),
+        winning.len()
+    );
+    for addr in &winning {
+        println!("  winning candidate: 0x{:016x}", addr);
+    }
+}
+
+/// Replicate scanner::extract_players' per-candidate walk and return the
+/// (bhid, struct_ptr) pairs it would have inserted. Empty vec means the
+/// candidate is not a real IntMap entry (or the entries' integrity check
+/// failed for every slot).
+fn walk_candidate(handle: HANDLE, addr: usize) -> Vec<(u32, usize)> {
+    let table_base = match addr.checked_sub(256 * 16) {
+        Some(b) => b,
+        None => return Vec::new(),
+    };
+    let mut td = vec![0u8; 512 * 16];
+    if !memory::read_memory(handle, table_base, &mut td) {
+        return Vec::new();
+    }
+
+    let mut yielded = Vec::new();
+    let mut seen: HashSet<u32> = HashSet::new();
+
+    for i in 0..512 {
+        let off = i * 16;
+        let atom = u32::from_le_bytes([td[off], td[off + 1], td[off + 2], td[off + 3]]);
+        let pad = u32::from_le_bytes([td[off + 4], td[off + 5], td[off + 6], td[off + 7]]);
+        if (atom & 7) != 6 || pad != 0 || atom <= 6 {
+            continue;
+        }
+        let bhid = atom >> 3;
+        if bhid == 0 || !seen.insert(bhid) {
+            continue;
+        }
+        let raw_ptr = u64::from_le_bytes([
+            td[off + 8],
+            td[off + 9],
+            td[off + 10],
+            td[off + 11],
+            td[off + 12],
+            td[off + 13],
+            td[off + 14],
+            td[off + 15],
+        ]);
+        let ptr = (raw_ptr & !7) as usize;
+        if ptr == 0 {
+            continue;
+        }
+        let mut obj = [0u8; 64];
+        if !memory::read_memory(handle, ptr, &mut obj) {
+            continue;
+        }
+        let id_check = u32::from_le_bytes([obj[44], obj[45], obj[46], obj[47]]);
+        let slot = u32::from_le_bytes([obj[60], obj[61], obj[62], obj[63]]);
+        if id_check != bhid || slot == 0 || slot > 4 {
+            continue;
+        }
+        yielded.push((bhid, ptr));
+    }
+
+    yielded
+}

--- a/apps/desktop/app/src/bin/intmap_probe.rs
+++ b/apps/desktop/app/src/bin/intmap_probe.rs
@@ -28,7 +28,7 @@ use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 use brawltome_detection::memory::{self, RegionCache};
-use brawltome_detection::scanner;
+use brawltome_detection::locate;
 
 use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
 
@@ -54,7 +54,7 @@ fn main() {
     let mut cache = RegionCache::new(regions);
     println!("Region cache built: {} regions", cache.regions.len());
 
-    let my_bhid = match scanner::find_my_bhid(handle, &mut cache) {
+    let my_bhid = match locate::find_my_bhid(handle, &mut cache) {
         Some(b) => b,
         None => {
             eprintln!("Local BhID not found (are you logged in?)");

--- a/apps/desktop/app/src/bin/login_probe.rs
+++ b/apps/desktop/app/src/bin/login_probe.rs
@@ -1,0 +1,170 @@
+//! Login-readiness probe for the v0.2.0 detection rewrite.
+//!
+//! Captures Brawlhalla window-state transitions during launch and login so
+//! we can identify a cheap, reliable signal that says "Brawlhalla is logged
+//! in, scan now." Today the detection cycle starts polling `find_my_bhid`
+//! immediately after attaching to the process, which costs ~55 s of wasted
+//! full-heap scanning during pre-login. The rewrite's Probing state will
+//! gate `find_my_bhid` on this signal.
+//!
+//! Usage:
+//!   1. Start this probe BEFORE launching Brawlhalla (so we catch the
+//!      pre-process state too):
+//!        cargo run -p brawltome-desktop --bin login_probe \
+//!          --features login-probe-tool --release
+//!   2. Launch Brawlhalla. Wait through splash, login screen, log in,
+//!      reach the main menu.
+//!   3. Press Ctrl+C to stop the probe.
+//!
+//! Output:
+//!   %LOCALAPPDATA%\com.brawltome.overlay\dumps\login_probe_<launch_ts>.txt
+//!
+//! Each line records: ISO-ish timestamp, Brawlhalla.exe pid (or
+//! "not_running"), and one entry per top-level window owned by the process
+//! formatted as `[<visible flag><title flag>] "<title>" / <class>`.
+
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime};
+
+use brawltome_detection::memory;
+
+use windows_sys::Win32::Foundation::{BOOL, HWND, LPARAM, TRUE};
+use windows_sys::Win32::UI::WindowsAndMessaging::{
+    EnumWindows, GetClassNameW, GetWindowTextW, GetWindowThreadProcessId, IsWindowVisible,
+};
+
+const POLL_INTERVAL: Duration = Duration::from_millis(1000);
+
+#[derive(Debug, Clone)]
+struct WindowInfo {
+    title: String,
+    class: String,
+    visible: bool,
+}
+
+struct EnumCtx {
+    target_pid: u32,
+    windows: Vec<WindowInfo>,
+}
+
+extern "system" fn enum_proc(hwnd: HWND, lparam: LPARAM) -> BOOL {
+    // Safety: lparam was set by the only caller of EnumWindows below to a
+    // pointer to a stack-resident EnumCtx that outlives the call.
+    let ctx = unsafe { &mut *(lparam as *mut EnumCtx) };
+
+    let mut wnd_pid: u32 = 0;
+    unsafe {
+        GetWindowThreadProcessId(hwnd, &mut wnd_pid);
+    }
+    if wnd_pid != ctx.target_pid {
+        return TRUE;
+    }
+
+    let mut title_buf = [0u16; 256];
+    let title_len =
+        unsafe { GetWindowTextW(hwnd, title_buf.as_mut_ptr(), title_buf.len() as i32) };
+    let title = String::from_utf16_lossy(&title_buf[..title_len.max(0) as usize]);
+
+    let mut class_buf = [0u16; 256];
+    let class_len =
+        unsafe { GetClassNameW(hwnd, class_buf.as_mut_ptr(), class_buf.len() as i32) };
+    let class = String::from_utf16_lossy(&class_buf[..class_len.max(0) as usize]);
+
+    let visible = unsafe { IsWindowVisible(hwnd) != 0 };
+
+    ctx.windows.push(WindowInfo {
+        title,
+        class,
+        visible,
+    });
+    TRUE
+}
+
+fn enumerate_windows_for_pid(pid: u32) -> Vec<WindowInfo> {
+    let mut ctx = EnumCtx {
+        target_pid: pid,
+        windows: Vec::new(),
+    };
+    unsafe {
+        EnumWindows(Some(enum_proc), &mut ctx as *mut _ as LPARAM);
+    }
+    ctx.windows
+}
+
+fn main() {
+    let launch_ts = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    let local_appdata = std::env::var("LOCALAPPDATA").unwrap_or_else(|_| ".".to_string());
+    let dumps_dir = PathBuf::from(local_appdata)
+        .join("com.brawltome.overlay")
+        .join("dumps");
+    if let Err(e) = std::fs::create_dir_all(&dumps_dir) {
+        eprintln!("Couldn't create {}: {}", dumps_dir.display(), e);
+        std::process::exit(1);
+    }
+    let session_path = dumps_dir.join(format!("login_probe_{launch_ts}.txt"));
+    println!("Login probe running. Output: {}", session_path.display());
+    println!("Launch Brawlhalla now. Press Ctrl+C when you've reached the main menu.");
+
+    let mut log_file = match OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&session_path)
+    {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("Couldn't open session file: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let _ = writeln!(log_file, "=== BrawlTome login-readiness probe ===");
+    let _ = writeln!(log_file, "Launch timestamp: {launch_ts}");
+    let _ = writeln!(log_file, "Polling every {} ms", POLL_INTERVAL.as_millis());
+    let _ = writeln!(log_file);
+
+    loop {
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        match memory::find_process_id("Brawlhalla.exe") {
+            None => {
+                let line = format!("[{now}] not_running");
+                println!("{line}");
+                let _ = writeln!(log_file, "{line}");
+            }
+            Some(pid) => {
+                let windows = enumerate_windows_for_pid(pid);
+                let summary: String = if windows.is_empty() {
+                    "(no top-level windows)".to_string()
+                } else {
+                    windows
+                        .iter()
+                        .map(|w| {
+                            format!(
+                                "[{}{}] \"{}\" / {}",
+                                if w.visible { 'V' } else { '_' },
+                                if w.title.is_empty() { '_' } else { 'T' },
+                                w.title,
+                                w.class
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                        .join(" | ")
+                };
+                let line = format!("[{now}] pid={pid} windows={}: {}", windows.len(), summary);
+                println!("{line}");
+                let _ = writeln!(log_file, "{line}");
+            }
+        }
+
+        std::thread::sleep(POLL_INTERVAL);
+    }
+}

--- a/apps/desktop/app/src/bin/pointer_scan.rs
+++ b/apps/desktop/app/src/bin/pointer_scan.rs
@@ -1,0 +1,724 @@
+//! PR-C2 research tool: backward pointer-scan against the .dmp files
+//! produced alongside dump_layout.rs's .txt files.
+//!
+//! Goal: find a stable pointer chain from a static module (Adobe AIR.dll,
+//! amdxx64.dll, etc.) to one of the player-struct addresses captured in the
+//! .txt. A "stable" chain holds the same `(module + module_offset, [step
+//! offsets])` template across all 5 dumps; per-launch base addresses differ
+//! but the offsets stay constant.
+//!
+//! Run from the repo root:
+//!   cargo run -p brawltome-desktop --bin pointer_scan --features pointer-scan-tool --release
+//!
+//! Reads every `dump_<ts>.dmp` + `dump_<ts>.txt` pair under
+//! %LOCALAPPDATA%\com.brawltome.overlay\dumps\, processes them in turn, and
+//! prints a ranked summary plus a markdown report to
+//! `%LOCALAPPDATA%\com.brawltome.overlay\dumps\pointer_scan_report.md`.
+
+use std::collections::HashMap;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use minidump::{
+    Minidump, MinidumpMemoryList, MinidumpMemory64List, MinidumpModuleList, Module,
+    UnifiedMemoryList,
+};
+
+const MAX_DEPTH: usize = 8;
+const DISPLACEMENT: i64 = 2048;
+/// Cap on how many distinct pointer addresses we recurse from per level. The
+/// number can explode combinatorially without this bound. Raised to capture
+/// more candidates per level; cross-dump intersection eliminates noise.
+const MAX_FANOUT_PER_LEVEL: usize = 256;
+/// Cap on total chains collected per dump; safety against pathological cases.
+const MAX_CHAINS_PER_DUMP: usize = 100_000;
+
+#[derive(Clone, Debug)]
+struct Module64 {
+    name: String,
+    base: u64,
+    size: u64,
+}
+
+#[derive(Clone, Debug)]
+struct MemRegion {
+    base: u64,
+    bytes: Vec<u8>,
+}
+
+struct DumpCtx {
+    label: String,
+    txt_path: PathBuf,
+    modules: Vec<Module64>,
+    memory: Vec<MemRegion>,
+    pointer_index: HashMap<u64, Vec<u64>>,
+    /// Player struct addresses extracted from the .txt file. These are
+    /// the pointer-scan targets.
+    targets: Vec<u64>,
+    /// Heap prefix (top-32-bit pattern of heap allocations) parsed from .txt.
+    heap_prefix: Option<u32>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct ChainTemplate {
+    module: String,
+    module_offset: u64,
+    /// Step offsets applied as `(read_u64(addr) & !7) + step_offset`.
+    /// Stored signed because games often use negative offsets to reach a
+    /// previous-field anchor in a struct.
+    steps: Vec<i64>,
+}
+
+#[derive(Clone, Debug)]
+struct ScoredChain {
+    template: ChainTemplate,
+    /// dump_label -> resolved target (or None if chain didn't resolve)
+    resolutions: Vec<(String, Option<u64>)>,
+}
+
+impl ScoredChain {
+    fn confirmed_count(&self) -> usize {
+        self.resolutions
+            .iter()
+            .filter(|(_, r)| r.is_some())
+            .count()
+    }
+    fn total_count(&self) -> usize {
+        self.resolutions.len()
+    }
+}
+
+fn main() {
+    let local_appdata = std::env::var("LOCALAPPDATA").unwrap_or_else(|_| ".".to_string());
+    let dumps_dir = PathBuf::from(local_appdata)
+        .join("com.brawltome.overlay")
+        .join("dumps");
+
+    println!("Reading dumps from: {}", dumps_dir.display());
+
+    let pairs = discover_dump_pairs(&dumps_dir);
+    if pairs.is_empty() {
+        eprintln!("No (.dmp, .txt) pairs found in {}", dumps_dir.display());
+        std::process::exit(1);
+    }
+    println!("Found {} dump pair(s)", pairs.len());
+
+    let mut contexts = Vec::new();
+    for (dmp, txt) in &pairs {
+        let label = dmp
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("?")
+            .to_string();
+        println!("\n=== Loading {} ===", label);
+        match load_dump(&label, dmp, txt) {
+            Ok(ctx) => {
+                println!(
+                    "  modules: {}, memory regions: {}, total bytes: {:.1} MB, pointer-index entries: {}, targets: {}",
+                    ctx.modules.len(),
+                    ctx.memory.len(),
+                    ctx.memory.iter().map(|r| r.bytes.len()).sum::<usize>() as f64 / 1048576.0,
+                    ctx.pointer_index.len(),
+                    ctx.targets.len(),
+                );
+                contexts.push(ctx);
+            }
+            Err(e) => {
+                eprintln!("  load failed: {}", e);
+            }
+        }
+    }
+
+    if contexts.len() < 2 {
+        eprintln!(
+            "Need at least 2 successfully-loaded dumps to cross-reference; got {}",
+            contexts.len()
+        );
+        std::process::exit(1);
+    }
+
+    // Scan each dump INDEPENDENTLY for backward chains. A template that is
+    // discovered as a candidate in multiple dumps is way more likely to be
+    // stable than one that only happened to resolve by chance via cross-
+    // reference forward-resolve.
+    println!("\n=== Pointer-scanning each dump independently ===");
+    let scan_start = Instant::now();
+
+    // template -> set of dump labels that found it as a candidate
+    let mut template_to_dumps: HashMap<ChainTemplate, Vec<String>> = HashMap::new();
+    for ctx in &contexts {
+        let mut per_dump_templates: HashMap<ChainTemplate, ()> = HashMap::new();
+        for &target in &ctx.targets {
+            let chains = backward_scan(ctx, target, MAX_DEPTH);
+            for c in chains {
+                per_dump_templates.entry(c).or_default();
+                if per_dump_templates.len() >= MAX_CHAINS_PER_DUMP {
+                    break;
+                }
+            }
+        }
+        println!(
+            "  {}: {} unique chain template(s) from {} target(s)",
+            ctx.label,
+            per_dump_templates.len(),
+            ctx.targets.len()
+        );
+        for (t, _) in per_dump_templates {
+            template_to_dumps.entry(t).or_default().push(ctx.label.clone());
+        }
+    }
+    println!(
+        "\n=== Backward scan total elapsed: {:.1}s; {} distinct templates across all dumps ===",
+        scan_start.elapsed().as_secs_f64(),
+        template_to_dumps.len()
+    );
+
+    // Stability bucket of "found as candidate in N dumps".
+    let mut found_in_n_dumps: HashMap<usize, usize> = HashMap::new();
+    for (_, found_dumps) in &template_to_dumps {
+        *found_in_n_dumps.entry(found_dumps.len()).or_default() += 1;
+    }
+    let mut bks: Vec<(usize, usize)> = found_in_n_dumps.into_iter().collect();
+    bks.sort_by(|a, b| b.0.cmp(&a.0));
+    println!("\n=== Candidates discovered in N dumps ===");
+    for (n, count) in &bks {
+        println!("  {}/{}: {} chain(s)", n, contexts.len(), count);
+    }
+
+    // For each template, do forward-resolve in EVERY dump to compute the
+    // landing-on-correct-target stability.
+    println!("\n=== Forward-resolving candidates in every dump ===");
+    let xref_start = Instant::now();
+    let mut scored: Vec<ScoredChain> = Vec::new();
+    for (template, _found_in) in template_to_dumps.iter() {
+        let mut resolutions: Vec<(String, Option<u64>)> = Vec::new();
+        for ctx in &contexts {
+            let resolved = resolve_chain(ctx, template);
+            let valid = resolved.map(|a| {
+                ctx.targets
+                    .iter()
+                    .any(|&t| (a as i64 - t as i64).abs() <= DISPLACEMENT)
+            });
+            resolutions.push((
+                ctx.label.clone(),
+                if valid.unwrap_or(false) { resolved } else { None },
+            ));
+        }
+        scored.push(ScoredChain {
+            template: template.clone(),
+            resolutions,
+        });
+    }
+
+    // Sort by confirmed count (forward-resolves to a valid target) descending,
+    // then by depth ascending (shorter chains preferred when tied).
+    scored.sort_by(|a, b| {
+        let ac = a.confirmed_count();
+        let bc = b.confirmed_count();
+        bc.cmp(&ac)
+            .then_with(|| a.template.steps.len().cmp(&b.template.steps.len()))
+    });
+
+    println!(
+        "\n=== Forward-resolve done in {:.1}s ===",
+        xref_start.elapsed().as_secs_f64()
+    );
+
+    // Print the top results.
+    let total_dumps = contexts.len();
+    let mut bucket_counts: HashMap<usize, usize> = HashMap::new();
+    for sc in &scored {
+        *bucket_counts.entry(sc.confirmed_count()).or_default() += 1;
+    }
+    println!("\n=== Stability distribution ===");
+    let mut buckets: Vec<(usize, usize)> = bucket_counts.into_iter().collect();
+    buckets.sort_by(|a, b| b.0.cmp(&a.0));
+    for (confirmed, count) in &buckets {
+        println!("  {}/{} dumps confirmed: {} chain(s)", confirmed, total_dumps, count);
+    }
+
+    println!("\n=== Top 20 chains (by confirmed count, then by depth) ===");
+    for sc in scored.iter().take(20) {
+        print_chain_summary(sc, total_dumps);
+    }
+
+    let report_path = dumps_dir.join("pointer_scan_report.md");
+    write_report(&report_path, &contexts, &scored, total_dumps);
+    println!("\nReport written: {}", report_path.display());
+}
+
+fn discover_dump_pairs(dir: &Path) -> Vec<(PathBuf, PathBuf)> {
+    let mut pairs = Vec::new();
+    if !dir.is_dir() {
+        return pairs;
+    }
+    let entries = match fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return pairs,
+    };
+    let mut dmps: Vec<PathBuf> = Vec::new();
+    let mut txts: HashMap<String, PathBuf> = HashMap::new();
+    for entry in entries.flatten() {
+        let p = entry.path();
+        if !p.is_file() {
+            continue;
+        }
+        let stem = match p.file_stem().and_then(|s| s.to_str()) {
+            Some(s) => s.to_string(),
+            None => continue,
+        };
+        match p.extension().and_then(|e| e.to_str()) {
+            Some("dmp") => dmps.push(p),
+            Some("txt") => {
+                txts.insert(stem, p);
+            }
+            _ => {}
+        }
+    }
+    for d in dmps {
+        let stem = d.file_stem().and_then(|s| s.to_str()).map(String::from);
+        if let Some(stem) = stem {
+            if let Some(txt) = txts.get(&stem) {
+                pairs.push((d.clone(), txt.clone()));
+            }
+        }
+    }
+    pairs.sort();
+    pairs
+}
+
+fn load_dump(
+    label: &str,
+    dmp_path: &Path,
+    txt_path: &Path,
+) -> Result<DumpCtx, String> {
+    let load_start = Instant::now();
+    let dump = Minidump::read_path(dmp_path).map_err(|e| format!("minidump open: {e}"))?;
+    println!("  parsed minidump headers in {:.2}s", load_start.elapsed().as_secs_f64());
+
+    let module_list: MinidumpModuleList = dump
+        .get_stream::<MinidumpModuleList>()
+        .map_err(|e| format!("module list: {e}"))?;
+    let modules: Vec<Module64> = module_list
+        .iter()
+        .map(|m| Module64 {
+            name: PathBuf::from(m.name.clone())
+                .file_name()
+                .and_then(|n| n.to_str())
+                .map(String::from)
+                .unwrap_or_else(|| m.name.clone()),
+            base: m.base_address(),
+            size: m.size(),
+        })
+        .collect();
+
+    // Prefer 64-bit memory list (full memory dumps); fall back to 32-bit.
+    let memory: Vec<MemRegion> = if let Ok(list) = dump.get_stream::<MinidumpMemory64List>() {
+        let unified = UnifiedMemoryList::Memory64(list);
+        unified
+            .iter()
+            .map(|m| MemRegion {
+                base: m.base_address(),
+                bytes: m.bytes().to_vec(),
+            })
+            .collect()
+    } else if let Ok(list) = dump.get_stream::<MinidumpMemoryList>() {
+        let unified = UnifiedMemoryList::Memory(list);
+        unified
+            .iter()
+            .map(|m| MemRegion {
+                base: m.base_address(),
+                bytes: m.bytes().to_vec(),
+            })
+            .collect()
+    } else {
+        return Err("no memory list in dump".to_string());
+    };
+
+    if memory.is_empty() {
+        return Err("memory list empty (was the dump captured as a full-memory dump?)".to_string());
+    }
+
+    let total_bytes: usize = memory.iter().map(|r| r.bytes.len()).sum();
+    println!(
+        "  loaded {} memory region(s), {} MB total in {:.2}s",
+        memory.len(),
+        total_bytes / 1048576,
+        load_start.elapsed().as_secs_f64()
+    );
+
+    // Build pointer index (only u64 values that look like valid pointers into
+    // memory or modules — drops 99%+ of random-data u64s).
+    let valid_ranges = build_valid_ranges(&memory, &modules);
+    let index_start = Instant::now();
+    let mut pointer_index: HashMap<u64, Vec<u64>> = HashMap::new();
+    for region in &memory {
+        let bytes = &region.bytes;
+        let len = bytes.len();
+        // Walk 8-byte-aligned u64 slots.
+        let mut off = 0;
+        while off + 8 <= len {
+            let val = u64::from_le_bytes([
+                bytes[off],
+                bytes[off + 1],
+                bytes[off + 2],
+                bytes[off + 3],
+                bytes[off + 4],
+                bytes[off + 5],
+                bytes[off + 6],
+                bytes[off + 7],
+            ]) & !7;
+            if is_valid_pointer(val, &valid_ranges) {
+                let here = region.base + off as u64;
+                pointer_index.entry(val).or_default().push(here);
+            }
+            off += 8;
+        }
+    }
+    println!(
+        "  pointer index built in {:.2}s ({} unique values, ~{} entries)",
+        index_start.elapsed().as_secs_f64(),
+        pointer_index.len(),
+        pointer_index.values().map(|v| v.len()).sum::<usize>(),
+    );
+
+    // Parse the matching .txt for player-struct targets.
+    let txt = fs::read_to_string(txt_path).map_err(|e| format!("read txt: {e}"))?;
+    let (targets, heap_prefix) = parse_txt(&txt);
+
+    Ok(DumpCtx {
+        label: label.to_string(),
+        txt_path: txt_path.to_path_buf(),
+        modules,
+        memory,
+        pointer_index,
+        targets,
+        heap_prefix,
+    })
+}
+
+fn build_valid_ranges(
+    memory: &[MemRegion],
+    modules: &[Module64],
+) -> Vec<(u64, u64)> {
+    let mut r: Vec<(u64, u64)> = Vec::new();
+    for region in memory {
+        r.push((region.base, region.base + region.bytes.len() as u64));
+    }
+    for m in modules {
+        r.push((m.base, m.base + m.size));
+    }
+    r.sort_by_key(|(a, _)| *a);
+    // Merge adjacent/overlapping ranges.
+    let mut merged: Vec<(u64, u64)> = Vec::new();
+    for (s, e) in r {
+        if let Some(last) = merged.last_mut() {
+            if s <= last.1 {
+                last.1 = last.1.max(e);
+                continue;
+            }
+        }
+        merged.push((s, e));
+    }
+    merged
+}
+
+fn is_valid_pointer(val: u64, ranges: &[(u64, u64)]) -> bool {
+    if val == 0 {
+        return false;
+    }
+    // Quick reject on obviously-garbage upper bits.
+    if val >> 48 != 0 {
+        return false;
+    }
+    // Binary search the merged range list.
+    match ranges.binary_search_by(|(s, _)| s.cmp(&val)) {
+        Ok(_) => true, // exact start of a range
+        Err(idx) => {
+            if idx == 0 {
+                return false;
+            }
+            let (s, e) = ranges[idx - 1];
+            val >= s && val < e
+        }
+    }
+}
+
+/// Parse the dump_layout.rs .txt for the player-struct addresses + heap prefix.
+fn parse_txt(txt: &str) -> (Vec<u64>, Option<u32>) {
+    let mut targets = Vec::new();
+    let mut heap_prefix: Option<u32> = None;
+    for line in txt.lines() {
+        let l = line.trim();
+        if let Some(rest) = l.strip_prefix("Heap prefix:") {
+            // "Heap prefix:  Some(489)"
+            if let Some(start) = rest.find("Some(") {
+                let after = &rest[start + 5..];
+                if let Some(end) = after.find(')') {
+                    if let Ok(p) = after[..end].parse::<u32>() {
+                        heap_prefix = Some(p);
+                    }
+                }
+            }
+        }
+        if let Some(addr_str) = l.strip_prefix("Player BhID ") {
+            // "Player BhID 5787742 at 0x000003859105ee48 (heap (...))"
+            if let Some(at_idx) = addr_str.find(" at 0x") {
+                let after = &addr_str[at_idx + 6..];
+                let hex: String = after.chars().take_while(|c| c.is_ascii_hexdigit()).collect();
+                if let Ok(a) = u64::from_str_radix(&hex, 16) {
+                    targets.push(a);
+                }
+            }
+        }
+    }
+    targets.sort();
+    targets.dedup();
+    (targets, heap_prefix)
+}
+
+/// Backward search: from `target`, find chains of length up to `max_depth`
+/// terminating at a static-module anchor.
+fn backward_scan(ctx: &DumpCtx, target: u64, max_depth: usize) -> Vec<ChainTemplate> {
+    // BFS-ish, accumulating chains. Each work item = (current_target,
+    // accumulated_steps_so_far_reversed).
+    let mut results: Vec<ChainTemplate> = Vec::new();
+    let mut visited: HashMap<u64, ()> = HashMap::new();
+
+    // (current_target, steps_collected_in_reverse_order)
+    let mut stack: Vec<(u64, Vec<i64>)> = vec![(target, Vec::new())];
+
+    while let Some((curr, steps)) = stack.pop() {
+        if steps.len() >= max_depth {
+            continue;
+        }
+
+        // Pull pointer addresses landing on curr ± DISPLACEMENT.
+        let mut hits = pointers_near(ctx, curr, DISPLACEMENT);
+        if hits.len() > MAX_FANOUT_PER_LEVEL {
+            // Sort hits with a deterministic order so different invocations of
+            // the tool don't flap. Prefer smaller positive deltas, then by
+            // module-anchor first (more useful for stability).
+            hits.sort_by(|a, b| {
+                let a_in_module = find_module(&ctx.modules, a.0).is_some();
+                let b_in_module = find_module(&ctx.modules, b.0).is_some();
+                b_in_module
+                    .cmp(&a_in_module)
+                    .then_with(|| a.1.abs().cmp(&b.1.abs()))
+            });
+            hits.truncate(MAX_FANOUT_PER_LEVEL);
+        }
+
+        for (ptr_at, delta) in hits {
+            // Build the new step list (`delta` is the offset added at this
+            // level after dereference + tag-mask: A_(k+1) = (read_u64(A_k) &
+            // !7) + delta). steps is in reverse order (deepest first).
+            let mut new_steps = steps.clone();
+            new_steps.push(delta);
+
+            if let Some((module_name, module_offset)) = find_module(&ctx.modules, ptr_at) {
+                // Reached a static anchor — record the chain in forward order.
+                let mut forward_steps = new_steps.clone();
+                forward_steps.reverse();
+                results.push(ChainTemplate {
+                    module: module_name,
+                    module_offset,
+                    steps: forward_steps,
+                });
+                if results.len() >= MAX_CHAINS_PER_DUMP {
+                    return results;
+                }
+                continue;
+            }
+
+            // Otherwise recurse.
+            if visited.insert(ptr_at, ()).is_some() {
+                continue;
+            }
+            stack.push((ptr_at, new_steps));
+        }
+    }
+
+    results
+}
+
+/// Find addresses A such that (read_u64(A) & !7) lands within [target -
+/// disp, target + disp]. Returns (A, delta) where delta = target -
+/// (read_u64(A) & !7), so the forward chain step at this level is `+delta`.
+fn pointers_near(ctx: &DumpCtx, target: u64, disp: i64) -> Vec<(u64, i64)> {
+    let mut out = Vec::new();
+    for delta in -disp..=disp {
+        // Skip non-aligned candidate values; we only indexed 8-aligned values.
+        let candidate_val = (target as i64 - delta) as u64;
+        if let Some(addrs) = ctx.pointer_index.get(&candidate_val) {
+            for &a in addrs {
+                out.push((a, delta));
+            }
+        }
+    }
+    out
+}
+
+fn find_module(modules: &[Module64], addr: u64) -> Option<(String, u64)> {
+    for m in modules {
+        if addr >= m.base && addr < m.base + m.size {
+            return Some((m.name.clone(), addr - m.base));
+        }
+    }
+    None
+}
+
+/// Forward-traverse a chain and return the resolved final address (or None
+/// if any read fails or any pointer arithmetic over/underflows.
+fn resolve_chain(ctx: &DumpCtx, t: &ChainTemplate) -> Option<u64> {
+    let m = ctx.modules.iter().find(|m| m.name == t.module)?;
+    let mut addr = m.base.checked_add(t.module_offset)?;
+    for &step in &t.steps {
+        let val = read_u64(ctx, addr)?;
+        let masked = val & !7;
+        addr = if step >= 0 {
+            masked.checked_add(step as u64)?
+        } else {
+            masked.checked_sub(step.unsigned_abs())?
+        };
+    }
+    Some(addr)
+}
+
+fn read_u64(ctx: &DumpCtx, addr: u64) -> Option<u64> {
+    for region in &ctx.memory {
+        let end = region.base.checked_add(region.bytes.len() as u64)?;
+        let addr_end = addr.checked_add(8)?;
+        if addr >= region.base && addr_end <= end {
+            let off = (addr - region.base) as usize;
+            // Defense-in-depth bounds re-check; the above guarantees this but
+            // the cost is one branch per call.
+            if off + 8 > region.bytes.len() {
+                continue;
+            }
+            return Some(u64::from_le_bytes([
+                region.bytes[off],
+                region.bytes[off + 1],
+                region.bytes[off + 2],
+                region.bytes[off + 3],
+                region.bytes[off + 4],
+                region.bytes[off + 5],
+                region.bytes[off + 6],
+                region.bytes[off + 7],
+            ]));
+        }
+    }
+    None
+}
+
+fn print_chain_summary(sc: &ScoredChain, total: usize) {
+    let confirmed = sc.confirmed_count();
+    let steps_str = sc
+        .template
+        .steps
+        .iter()
+        .map(|s| format_signed_hex(*s))
+        .collect::<Vec<_>>()
+        .join(", ");
+    println!(
+        "  [{:>2}/{}] {}+0x{:x} -> [{}]",
+        confirmed, total, sc.template.module, sc.template.module_offset, steps_str
+    );
+    for (label, res) in &sc.resolutions {
+        match res {
+            Some(a) => println!("      {}: 0x{:016x} OK", label, a),
+            None => println!("      {}: <unresolved>", label),
+        }
+    }
+}
+
+fn format_signed_hex(v: i64) -> String {
+    if v >= 0 {
+        format!("+0x{:x}", v)
+    } else {
+        format!("-0x{:x}", v.unsigned_abs())
+    }
+}
+
+fn write_report(
+    path: &Path,
+    contexts: &[DumpCtx],
+    scored: &[ScoredChain],
+    total: usize,
+) {
+    let mut f = match fs::File::create(path) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("Couldn't write report to {}: {}", path.display(), e);
+            return;
+        }
+    };
+    let _ = writeln!(f, "# PR-C2 Pointer-Scan Report\n");
+    let _ = writeln!(f, "Dumps analyzed:");
+    for ctx in contexts {
+        let _ = writeln!(
+            f,
+            "- `{}` (heap_prefix={:?}, {} player targets, {} memory regions, {:.0} MB)",
+            ctx.label,
+            ctx.heap_prefix,
+            ctx.targets.len(),
+            ctx.memory.len(),
+            ctx.memory.iter().map(|r| r.bytes.len()).sum::<usize>() as f64 / 1048576.0
+        );
+    }
+    let _ = writeln!(f);
+
+    let mut buckets: HashMap<usize, usize> = HashMap::new();
+    for sc in scored {
+        *buckets.entry(sc.confirmed_count()).or_default() += 1;
+    }
+    let mut bks: Vec<(usize, usize)> = buckets.into_iter().collect();
+    bks.sort_by(|a, b| b.0.cmp(&a.0));
+    let _ = writeln!(f, "## Stability distribution\n");
+    let _ = writeln!(f, "| Confirmed dumps | Chain count |");
+    let _ = writeln!(f, "|---|---|");
+    for (confirmed, count) in &bks {
+        let _ = writeln!(f, "| {}/{} | {} |", confirmed, total, count);
+    }
+    let _ = writeln!(f);
+
+    let _ = writeln!(f, "## Top 30 chains\n");
+    for sc in scored.iter().take(30) {
+        let confirmed = sc.confirmed_count();
+        let _ = writeln!(
+            f,
+            "### {}/{}: `{} + 0x{:x}` ({} steps)",
+            confirmed, total, sc.template.module, sc.template.module_offset, sc.template.steps.len()
+        );
+        let _ = writeln!(
+            f,
+            "Steps: `[{}]`",
+            sc.template
+                .steps
+                .iter()
+                .map(|s| format_signed_hex(*s))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        let _ = writeln!(f);
+        let _ = writeln!(f, "Resolutions:");
+        for (label, res) in &sc.resolutions {
+            match res {
+                Some(a) => {
+                    let _ = writeln!(f, "- `{}`: 0x{:016x}", label, a);
+                }
+                None => {
+                    let _ = writeln!(f, "- `{}`: unresolved", label);
+                }
+            }
+        }
+        let _ = writeln!(f);
+    }
+
+    // Suppress unused-field warnings for fields that exist for future use.
+    for ctx in contexts {
+        let _ = ctx.txt_path.display();
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 of the v0.2.0 detection rewrite (4 phases total).

- Bumps detection submodule to merged Phase 1 (module split into 11 focused files; pure refactor; no behavior change)
- Updates research probes (\`intmap_probe\`, \`dump_layout\`) to use the new module paths

## What changes for users

Nothing. This is internal restructuring. The \`DetectionService\` trait + \`GameEvent\` shapes are unchanged. Behavior is byte-for-byte identical to v0.1.4.

## What changes for maintainers

- \`apps/desktop/detection/src/\` goes from 3 files (~1200 lines total) to 11 files, each under ~280 lines
- \`LayoutSpec\` config struct in \`layout.rs\` is now the single source of truth for Brawlhalla offsets
- \`CS_CHAR_SELECT\` (state value 16) renamed to \`CS_MATCHMAKING\` per an empirical correction (state 16 is matchmaking, not in-game character selection)

See the detection submodule PR: https://github.com/NickTacke/brawltome-detection/pull/2

## Phasing

- Phase 1 (this PR): module split + LayoutSpec
- Phase 2: multi-prefix RegionCache + drop dead/workaround code
- Phase 3: Probing state with login-readiness gate (~50 s cold-start fix)
- Phase 4: cleanup pass

## Test plan

- [x] \`cargo build --release\` (workspace) succeeds
- [x] \`cargo test -p brawltome-detection\` passes (10/10)
- [x] All 4 research binaries build with their feature flags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added developer debugging tools behind optional feature flags to support memory analysis and investigation during development. These tools are not included in standard builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->